### PR TITLE
Several changes and fixes split up into single commits.

### DIFF
--- a/index.js
+++ b/index.js
@@ -92,6 +92,7 @@
 
 	let denominators = [1, 2, 5, 10];
 	let clickDetectionMs = 120;
+    let doubleClickTimeoutMs = 400;
 
 	function getPixelRatio(ctx) {
 		const dpr = window.devicePixelRatio || 1,
@@ -296,6 +297,7 @@
 		let selectionRect = null;
 		let drag = null;
 		let clickDurarion = null;
+        let lastClickTime = 0;
 		let scrollingTimeRef = null;
 		let selectedKeyframes = [];
 		let intervalReference = null;
@@ -586,9 +588,21 @@
 
 
 		function onMouseDown(args) {
+            var isDoubleClick = Date.now() - lastClickTime < doubleClickTimeoutMs;
+            lastClickTime = Date.now();
+
 			// Prevent drag of the canvas if canvas is selected as text:
 			clearBrowserSelection();
 			startPos = trackMousePos(canvas, args);
+            startPos.snapVal = snapVal(startPos.val);
+
+            if (isDoubleClick) {
+                emit('doubleclick', startPos);
+                return;
+            }
+
+            emit('mousedown', startPos);
+
 			clickDurarion = new Date();
 			currentPos = startPos;
 			drag = getDraggable(currentPos);

--- a/index.js
+++ b/index.js
@@ -926,7 +926,7 @@
 			const pos = getMousePos(canvas, mouseArgs);
 			pos.scrollLeft = scrollContainer.scrollLeft;
 			pos.scrollTop = scrollContainer.scrollTop;
-			pos.val = pxToVal(pos.x);
+			pos.val = pxToVal(pos.x + pos.scrollLeft);
 
 			if (startPos) {
 				if (!selectionRect) {

--- a/index.js
+++ b/index.js
@@ -487,7 +487,7 @@
 					let x = mousePos.x;
 					if (x <= 0)
 						x = 0;
-					val = pxToVal(scrollContainer.scrollLeft + x, false);
+					let val = pxToVal(scrollContainer.scrollLeft + x, false);
 					let diff = canvas.clientWidth / x;
 
 					let zoom = sign(event.deltaY) * options.zoom * options.zoomSpeed;

--- a/index.js
+++ b/index.js
@@ -82,10 +82,12 @@
 		// scroll by drag speed (from 0 to 1)
 		scrollByDragSpeed: 0.12,
 		id: '',
-		// Whether keyframes draggable. Can be also configured by a keyframe property draggable 
+		// Whether keyframes draggable. Can be also configured by a keyframe property draggable
 		keyframesDraggable: true,
-		// Whether keyframes lanes draggable. Can be also configured by a lane property draggable 
-		keyframesLanesDraggable: true
+		// Whether keyframes lanes draggable. Can be also configured by a lane property draggable
+		keyframesLanesDraggable: true,
+		// On macOS, the Meta aka Command key is used instead of Ctrl. Set this to true if you are running on a mac environment.
+		controlKeyIsMetaKey: false
 	}
 
 	let denominators = [1, 2, 5, 10];
@@ -476,7 +478,7 @@
 		}
 
 		scrollContainer.addEventListener("wheel", function (event) {
-			if (event.ctrlKey) {
+			if (controlKeyPressed(event)) {
 				event.preventDefault();
 				if (options.zoomSpeed > 0 && options.zoomSpeed <= 1) {
 					let mousePos = getMousePos(canvas, event);
@@ -567,7 +569,7 @@
 
 		document.addEventListener('keydown', (function (e) {
 			// ctrl + a. Select all keyframes
-			if (e.which === 65 && e.ctrlKey) {
+			if (e.which === 65 && controlKeyPressed(e)) {
 				performSelection(true);
 				e.preventDefault();
 				return false;
@@ -593,10 +595,10 @@
 			// Select keyframes on mouse down
 			if (drag) {
 				if (drag.type == 'keyframe') {
-					drag.startedWithCtrl = args.ctrlKey;
+					drag.startedWithCtrl = controlKeyPressed(args);
 					drag.startedWithShiftKey = args.shiftKey;
 					// get all related selected keyframes if we are selecting one.
-					if (!drag.obj.selected && !args.ctrlKey && !args.shiftKey) {
+					if (!drag.obj.selected && !controlKeyPressed(args) && !args.shiftKey) {
 						performSelection(true, drag.obj, 'keyframe');
 					}
 
@@ -776,13 +778,13 @@
 			let isChanged = false;
 			if (drag && drag.type == 'keyframe') {
 				let isSelected = true;
-				if ((drag.startedWithCtrl && args.ctrlKey) || (drag.startedWithShiftKey && args.shiftKey)) {
-					if (args.ctrlKey) {
+				if ((drag.startedWithCtrl && controlKeyPressed(args)) || (drag.startedWithShiftKey && args.shiftKey)) {
+                    if (controlKeyPressed(args)) {
 						isSelected = !drag.obj.selected
 					}
 				}
 				// Reverse selected keyframe selection by a click:
-				isChanged |= performSelection(isSelected, drag.obj, 'keyframe', args.ctrlKey || args.shiftKey);
+				isChanged |= performSelection(isSelected, drag.obj, 'keyframe', controlKeyPressed(args) || args.shiftKey);
 
 				if (args.shiftKey) {
 					// change timeline pos:
@@ -1735,6 +1737,10 @@
 		}
 
 		this.redraw = redraw;
+
+		function controlKeyPressed(e) {
+            return (options.controlKeyIsMetaKey || defaultOptions.controlKeyIsMetaKey) ? e.metaKey : e.ctrlKey;
+        }
 
 		function onKeyframesSelected(keyframe) {
 			emit('selected', keyframe);

--- a/index.js
+++ b/index.js
@@ -1,599 +1,594 @@
-(typeof navigator !== "undefined") && (function (window, factory) {
-	// Check require.js lib
-	if (typeof define === "function" && define.amd) {
-		define(function () { return factory(window) });
-	} else if (typeof module === "object" && module.exports) {
-		module.exports = factory(window);
-	} else {
-		window.animationTimeline = factory(window);
-	}
-}(window, function (window) {
+function sign(p) {
+    if (Math.sign) {
+        return Math.sign(p);
+    }
+    return p >= 0 ? 1 : -1;
+}
 
-	function sign(p) {
-		if (Math.sign) {
-			return Math.sign(p);
-		}
-		return p >= 0 ? 1 : -1;
-	}
+var document = window.document;
 
-	var document = window.document;
+function clearBrowserSelection() {
+    if (window.getSelection) {
+        window.getSelection().removeAllRanges();
+    } else if (document.selection) {
+        document.selection.empty();
+    }
+}
 
-	function clearBrowserSelection() {
-		if (window.getSelection) { window.getSelection().removeAllRanges(); }
-		else if (document.selection) { document.selection.empty(); }
-	}
+let defaultOptions = {
+    snapsPerSeconds: 5, // from 1 to 60
+    snapEnabled: true,
+    /**
+     *  Snap all selected keyframes as bundle during the drag.
+     */
+    snapAllKeyframesOnMove: false,
+    timelineThicknessPx: 2,
+    timelineMarginTopPx: 15,
+    timelineCapWidthPx: 4,
+    timelineCapHeightPx: 10,
+    timelineTriangleCap: false,
+    timelineRectCap: true,
+    // approximate step in px for 1 second
+    stepPx: 120,
+    stepSmallPx: 30,
+    smallSteps: 50,
+    // additional left margin to start the gauge from
+    leftMarginPx: 25,
+    minTimelineToDispayMs: 5000,
+    headerBackground: '#101011',
+    selectedLaneColor: '#333333',
+    backgroundColor: '#101011',
+    timeIndicatorColor: 'DarkOrange',
+    labelsColor: '#D5D5D5',
+    laneLabelsColor: '#D5D5D5',
+    tickColor: '#D5D5D5',
+    selectionColor: 'White',
+    // Lanes colors
+    laneColor: '#252526', //'#252526',37373D
+    alternateLaneColor: 'black', //333333
+    keyframesLaneColor: '#094771',
+    // keyframe color. can be overrided by a keyframe 'color' property.
+    keyframeColor: 'red',
+    // Shape of the keyframe: none|rhomb|circle|rect
+    keyframeShape: 'rhomb',
+    // selected keyframe color. can be overrider by a keyframe 'selectedColor' property.
+    selectedKeyframeColor: 'DarkOrange',
+    keyframeBorderColor: 'Black',
+    useAlternateLaneColor: false,
+    keyframeBorderThicknessPx: 0.2,
+    // can be a number or 'auto'. can be overriden by 'keyframe.size'. Auto is calculated based on the laneHeightPx.
+    keyframeSizePx: 'auto',
+    laneHeightPx: 24,
+    laneMarginPx: 2,
+    // Size of the lane in pixels. Can be 'auto' than size is based on the 'laneHeightPx'. can be overriden by lane 'lane.keyframesLaneSizePx'.
+    keyframesLaneSizePx: 'auto',
+    headerHeight: 30,
+    ticksFont: "11px sans-serif",
+    zoom: 1000,
+    // Zoom speed. Use percent of the screen to set zoom speed.
+    zoomSpeed: 0.1,
+    // Max zoom
+    zoomMin: 80,
+    // Min zoom
+    zoomMax: 8000,
+    // scroll by drag speed (from 0 to 1)
+    scrollByDragSpeed: 0.12,
+    id: '',
+    // Whether keyframes draggable. Can be also configured by a keyframe property draggable
+    keyframesDraggable: true,
+    // Whether keyframes lanes draggable. Can be also configured by a lane property draggable
+    keyframesLanesDraggable: true,
+    controlKeyIsMetaKey: false
+}
 
-	let defaultOptions = {
-		snapsPerSeconds: 5, // from 1 to 60
-		snapEnabled: true,
-		/**
-		 *  Snap all selected keyframes as bundle during the drag.
-		 */
-		snapAllKeyframesOnMove: false,
-		timelineThicknessPx: 2,
-		timelineMarginTopPx: 15,
-		timelineCapWidthPx: 4,
-		timelineCapHeightPx: 10,
-		timelineTriangleCap: false,
-		timelineRectCap: true,
-		// approximate step in px for 1 second 
-		stepPx: 120,
-		stepSmallPx: 30,
-		smallSteps: 50,
-		// additional left margin to start the gauge from
-		leftMarginPx: 25,
-		minTimelineToDispayMs: 5000,
-		headerBackground: '#101011',
-		selectedLaneColor: '#333333',
-		backgroundColor: '#101011',
-		timeIndicatorColor: 'DarkOrange',
-		labelsColor: '#D5D5D5',
-		laneLabelsColor: '#D5D5D5',
-		tickColor: '#D5D5D5',
-		selectionColor: 'White',
-		// Lanes colors
-		laneColor: '#252526', //'#252526',37373D
-		alternateLaneColor: 'black',//333333
-		keyframesLaneColor: '#094771',
-		// keyframe color. can be overrided by a keyframe 'color' property.
-		keyframeColor: 'red',
-		// Shape of the keyframe: none|rhomb|circle|rect
-		keyframeShape: 'rhomb',
-		// selected keyframe color. can be overrider by a keyframe 'selectedColor' property.
-		selectedKeyframeColor: 'DarkOrange',
-		keyframeBorderColor: 'Black',
-		useAlternateLaneColor: false,
-		keyframeBorderThicknessPx: 0.2,
-		// can be a number or 'auto'. can be overriden by 'keyframe.size'. Auto is calculated based on the laneHeightPx.
-		keyframeSizePx: 'auto',
-		laneHeightPx: 24,
-		laneMarginPx: 2,
-		// Size of the lane in pixels. Can be 'auto' than size is based on the 'laneHeightPx'. can be overriden by lane 'lane.keyframesLaneSizePx'. 
-		keyframesLaneSizePx: 'auto',
-		headerHeight: 30,
-		ticksFont: "11px sans-serif",
-		zoom: 1000,
-		// Zoom speed. Use percent of the screen to set zoom speed. 
-		zoomSpeed: 0.1,
-		// Max zoom
-		zoomMin: 80,
-		// Min zoom
-		zoomMax: 8000,
-		// scroll by drag speed (from 0 to 1)
-		scrollByDragSpeed: 0.12,
-		id: '',
-		// Whether keyframes draggable. Can be also configured by a keyframe property draggable
-		keyframesDraggable: true,
-		// Whether keyframes lanes draggable. Can be also configured by a lane property draggable
-		keyframesLanesDraggable: true,
-		// On macOS, the Meta aka Command key is used instead of Ctrl. Set this to true if you are running on a mac environment.
-		controlKeyIsMetaKey: false
-	}
+let denominators = [1, 2, 5, 10];
+let clickDetectionMs = 120;
+let doubleClickTimeoutMs = 400;
 
-	let denominators = [1, 2, 5, 10];
-	let clickDetectionMs = 120;
-    let doubleClickTimeoutMs = 400;
+function getPixelRatio(ctx) {
+    const dpr = window.devicePixelRatio || 1,
+        bsr = ctx.webkitBackingStorePixelRatio ||
+        ctx.mozBackingStorePixelRatio ||
+        ctx.msBackingStorePixelRatio ||
+        ctx.oBackingStorePixelRatio ||
+        ctx.backingStorePixelRatio || 1;
 
-	function getPixelRatio(ctx) {
-		const dpr = window.devicePixelRatio || 1,
-			bsr = ctx.webkitBackingStorePixelRatio ||
-				ctx.mozBackingStorePixelRatio ||
-				ctx.msBackingStorePixelRatio ||
-				ctx.oBackingStorePixelRatio ||
-				ctx.backingStorePixelRatio || 1;
+    return dpr / bsr;
+}
 
-		return dpr / bsr;
-	}
+function msToHMS(ms, isSeconds) {
+    // 1- Convert to seconds:
+    var seconds = ms / 1000;
+    if (isSeconds) {
+        seconds = ms;
+    }
 
-	function msToHMS(ms, isSeconds) {
-		// 1- Convert to seconds:
-		var seconds = ms / 1000;
-		if (isSeconds) {
-			seconds = ms;
-		}
+    var year = Math.floor(seconds / (365 * 86400));
+    seconds = seconds % (365 * 86400);
 
-		var year = Math.floor(seconds / (365 * 86400));
-		seconds = seconds % (365 * 86400);
+    var days = Math.floor(seconds / 86400);
+    seconds = seconds % 86400;
 
-		var days = Math.floor(seconds / 86400);
-		seconds = seconds % 86400;
+    // 2- Extract hours:
+    var hours = parseInt(seconds / 3600); // 3,600 seconds in 1 hour
+    seconds = seconds % 3600; // seconds remaining after extracting hours
+    // 3- Extract minutes:
+    var minutes = parseInt(seconds / 60); // 60 seconds in 1 minute
+    // 4- Keep only seconds not extracted to minutes:
+    seconds = (seconds % 60);
+    let str = '';
+    if (year) {
+        str += year + ":";
+    }
 
-		// 2- Extract hours:
-		var hours = parseInt(seconds / 3600); // 3,600 seconds in 1 hour
-		seconds = seconds % 3600; // seconds remaining after extracting hours
-		// 3- Extract minutes:
-		var minutes = parseInt(seconds / 60); // 60 seconds in 1 minute
-		// 4- Keep only seconds not extracted to minutes:
-		seconds = (seconds % 60);
-		let str = '';
-		if (year) {
-			str += year + ":";
-		}
+    if (days) {
+        str += days + ":";
+    }
 
-		if (days) {
-			str += days + ":";
-		}
+    if (hours) {
+        str += hours + ":";
+    }
 
-		if (hours) {
-			str += hours + ":";
-		}
+    if (minutes) {
+        str += minutes + ":";
+    }
 
-		if (minutes) {
-			str += minutes + ":";
-		}
+    if (!isNaN(seconds)) {
+        str += seconds;
+    }
 
-		if (!isNaN(seconds)) {
-			str += seconds;
-		}
-
-		return str;
-	}
+    return str;
+}
 
 
-	/**
-	 * Check rectangle overlap.
-	 * @param {number} x1 
-	 * @param {number} y1 
-	 * @param {object} rectangle 
-	 */
-	function isOverlap(x, y, rectangle) {
-		if (!rectangle) {
-			console.log('Rectange cannot be empty');
-			return false;
-		}
+/**
+ * Check rectangle overlap.
+ * @param {number} x1
+ * @param {number} y1
+ * @param {object} rectangle
+ */
+function isOverlap(x, y, rectangle) {
+    if (!rectangle) {
+        console.log('Rectange cannot be empty');
+        return false;
+    }
 
-		if (rectangle.x <= x && (rectangle.x + rectangle.w) >= x &&
-			rectangle.y <= y && (rectangle.y + rectangle.h) >= y) {
-			return true;
-		}
+    if (rectangle.x <= x && (rectangle.x + rectangle.w) >= x &&
+        rectangle.y <= y && (rectangle.y + rectangle.h) >= y) {
+        return true;
+    }
 
-		return false;
-	}
+    return false;
+}
 
-	function isRectOverlap(rect, rect2) {
-		if (!rect || !rect2) {
-			console.log('Rectanges cannot be empty');
-			return false;
-		}
+function isRectOverlap(rect, rect2) {
+    if (!rect || !rect2) {
+        console.log('Rectanges cannot be empty');
+        return false;
+    }
 
-		// If one rectangle is on left side of other  
-		if (rect.x > rect2.x + rect2.w || rect2.x > rect.x + rect.w) {
-			return true;
-		}
+    // If one rectangle is on left side of other
+    if (rect.x > rect2.x + rect2.w || rect2.x > rect.x + rect.w) {
+        return true;
+    }
 
-		// If one rectangle is above other  
-		if (rect.y < rect2.y + rect2.h || rect2.y < rect.y + rect.h) {
-			return true;
-		}
-		return false;
-	}
+    // If one rectangle is above other
+    if (rect.y < rect2.y + rect2.h || rect2.y < rect.y + rect.h) {
+        return true;
+    }
+    return false;
+}
 
-	function getDistance(x1, y1, x2, y2) {
-		if (x2 != undefined && y2 != undefined) {
-			return Math.sqrt(Math.pow(x1 - x2, 2) + Math.pow(y1 - y2, 2));
-		}
-		else {
-			return Math.abs(x1 - y1);
-		}
-	}
+function getDistance(x1, y1, x2, y2) {
+    if (x2 != undefined && y2 != undefined) {
+        return Math.sqrt(Math.pow(x1 - x2, 2) + Math.pow(y1 - y2, 2));
+    } else {
+        return Math.abs(x1 - y1);
+    }
+}
 
-	function getPowArgument(toCheck) {
-		if (!toCheck || toCheck === 0) {
-			return 1;
-		}
-		// some optimiazation for numbers:
-		if (toCheck >= 10 && toCheck < 100) {
-			return 1;
-		} else if (toCheck >= 100 && toCheck < 1000) {
-			return 2;
-		} else if (toCheck >= 1000 && toCheck < 10000) {
-			return 3;
-		}
+function getPowArgument(toCheck) {
+    if (!toCheck || toCheck === 0) {
+        return 1;
+    }
+    // some optimiazation for numbers:
+    if (toCheck >= 10 && toCheck < 100) {
+        return 1;
+    } else if (toCheck >= 100 && toCheck < 1000) {
+        return 2;
+    } else if (toCheck >= 1000 && toCheck < 10000) {
+        return 3;
+    }
 
-		toCheck = Math.abs(toCheck);
-		var category = 0;
-		var sign = sign(toCheck);
-		if (toCheck > 1) {
-			while (toCheck >= 1) {
-				toCheck = Math.floor(toCheck / 10.0);
-				category++;
-			}
+    toCheck = Math.abs(toCheck);
+    var category = 0;
+    var sign = sign(toCheck);
+    if (toCheck > 1) {
+        while (toCheck >= 1) {
+            toCheck = Math.floor(toCheck / 10.0);
+            category++;
+        }
 
-			return sign * category - 1;
-		}
-		else if (toCheck > 0.0) {
-			// Get number of zeros before the number.
-			var zerosCount = Math.floor(Math.log(toCheck) / Math.log(10) + 1);
-			zerosCount = zerosCount - 1;
-			return zerosCount;
-		}
-		else {
-			return 1;
-		}
-	}
+        return sign * category - 1;
+    } else if (toCheck > 0.0) {
+        // Get number of zeros before the number.
+        var zerosCount = Math.floor(Math.log(toCheck) / Math.log(10) + 1);
+        zerosCount = zerosCount - 1;
+        return zerosCount;
+    } else {
+        return 1;
+    }
+}
 
-	let instance = {};
-	instance.initialize = function (options, lanes) {
+export default class AnimationTimeline {
+    constructor(options, lanes) {
 
-		var scrollContainer = document.getElementById(options.id);
-		if (!scrollContainer) {
-			console.log('options.id is mandatory!');
-			return;
-		}
+        var scrollContainer = document.getElementById(options.id);
+        if (!scrollContainer) {
+            console.log('options.id is mandatory!');
+            return;
+        }
 
-		scrollContainer.style.overflow = "scroll";
-		scrollContainer.style.position = "relative";
-		scrollContainer.style.touchAction = "none";
-		var size = document.createElement("div");
-		var canvas = document.createElement("canvas");
+        scrollContainer.style.overflow = "scroll";
+        scrollContainer.style.position = "relative";
+        scrollContainer.style.touchAction = "none";
+        var size = document.createElement("div");
+        var canvas = document.createElement("canvas");
 
-		if (!canvas || !canvas.getContext) {
-			console.log('Cannot initialize canvas context.');
-			return null;
-		}
+        if (!canvas || !canvas.getContext) {
+            console.log('Cannot initialize canvas context.');
+            return null;
+        }
 
-		// Generate size container:
-		canvas.style.cssText = 'image-rendering: -moz-crisp-edges;' +
-			'image-rendering: -webkit-crisp-edges;' +
-			'image-rendering: pixelated;' +
-			'image-rendering: crisp-edges;' +
-			'user-select: none;' +
-			'-webkit-user-select: none;' +
-			'-khtml-user-select: none;' +
-			'-moz-user-select: none;' +
-			'-o-user-select: none;' +
-			'user-select: none;' +
-			'touch-action: none;' +
-			'position: absolute;' +
-			'top: 0;' +
-			'left: 0;' +
-			'width: 100%;' +
-			'padding: inherit' +
-			'height: 100%;';
+        // Generate size container:
+        canvas.style.cssText = 'image-rendering: -moz-crisp-edges;' +
+            'image-rendering: -webkit-crisp-edges;' +
+            'image-rendering: pixelated;' +
+            'image-rendering: crisp-edges;' +
+            'user-select: none;' +
+            '-webkit-user-select: none;' +
+            '-khtml-user-select: none;' +
+            '-moz-user-select: none;' +
+            '-o-user-select: none;' +
+            'user-select: none;' +
+            'touch-action: none;' +
+            'position: absolute;' +
+            'top: 0;' +
+            'left: 0;' +
+            'width: 100%;' +
+            'padding: inherit' +
+            'height: 100%;';
 
-		size.style.width = size.style.height = canvas.style.width = canvas.style.height = "100%";
-		// add the text node to the newly created div
-		scrollContainer.appendChild(size);
-		scrollContainer.appendChild(canvas);
+        size.style.width = size.style.height = canvas.style.width = canvas.style.height = "100%";
+        // add the text node to the newly created div
+        scrollContainer.appendChild(size);
+        scrollContainer.appendChild(canvas);
 
-		setOptions(options);
+        setOptions(options);
 
-		if (options.backgroundColor) {
-			scrollContainer.style.background = options.backgroundColor;
-		}
+        if (options.backgroundColor) {
+            scrollContainer.style.background = options.backgroundColor;
+        }
 
-		if (!options.stepPx) {
-			options.stepPx = defaultOptions.stepPx;
-		}
+        if (!options.stepPx) {
+            options.stepPx = defaultOptions.stepPx;
+        }
 
-		options.snapsPerSeconds = Math.max(0, Math.min(60, options.snapsPerSeconds));
+        options.snapsPerSeconds = Math.max(0, Math.min(60, options.snapsPerSeconds));
 
-		let timeLine = {
-			val: 0,
-		};
+        let timeLine = {
+            val: 0,
+        };
 
-		let startPos = null;
-		let currentPos = null;
-		let selectionRect = null;
-		let drag = null;
-		let clickDurarion = null;
+        let startPos = null;
+        let currentPos = null;
+        let selectionRect = null;
+        let drag = null;
+        let clickDurarion = null;
         let lastClickTime = 0;
-		let scrollingTimeRef = null;
-		let selectedKeyframes = [];
-		let intervalReference = null;
-		let lastCallDate = null;
-		let isPanStarted = false;
-		let isPanMode = false;
-		var ctx = canvas.getContext("2d");
-		drawLine = function (ctx, x1, y1, x2, y2) {
-			ctx.moveTo(x1, y1);
-			ctx.lineTo(x2, y2);
-		}
+        let scrollingTimeRef = null;
+        let selectedKeyframes = [];
+        let intervalReference = null;
+        let lastCallDate = null;
+        let isPanStarted = false;
+        let isPanMode = false;
+        var ctx = canvas.getContext("2d");
 
-		var pixelRatio = getPixelRatio(ctx);
-		function getMousePos(canvas, evt) {
+        var drawLine = function (ctx, x1, y1, x2, y2) {
+            ctx.moveTo(x1, y1);
+            ctx.lineTo(x2, y2);
+        }
 
-			let radius = 1;
-			if (evt.changedTouches && evt.changedTouches.length > 0) {
-				// TODO: implement better support of this:
-				let touch = evt.changedTouches[0];
-				if (isNaN(evt.clientX)) {
-					evt.clientX = touch.clientX;
-					evt.clientY = touch.clientY;
-					radius = Math.max(radius, touch.radiusX, touch.radiusY);
-				}
-			}
+        var pixelRatio = getPixelRatio(ctx);
 
-			var rect = canvas.getBoundingClientRect(), // abs. size of element
-				scaleX = canvas.width / pixelRatio / rect.width, // relationship bitmap vs. element for X
-				scaleY = canvas.height / pixelRatio / rect.height; // relationship bitmap vs. element for Y
+        function getMousePos(canvas, evt) {
 
-			let x = (evt.clientX - rect.left) * scaleX;
-			let y = (evt.clientY - rect.top) * scaleY;
-			// scale mouse coordinates after they have been adjusted to be relative to element
-			return {
-				x: x,
-				y: y,
-				radius
-			}
-		}
+            let radius = 1;
+            if (evt.changedTouches && evt.changedTouches.length > 0) {
+                // TODO: implement better support of this:
+                let touch = evt.changedTouches[0];
+                if (isNaN(evt.clientX)) {
+                    evt.clientX = touch.clientX;
+                    evt.clientY = touch.clientY;
+                    radius = Math.max(radius, touch.radiusX, touch.radiusY);
+                }
+            }
 
-		function rescale(scrollMode, newWidth, newHeight) {
-			var width = scrollContainer.clientWidth * pixelRatio;
-			var height = scrollContainer.clientHeight * pixelRatio;
-			if (width != ctx.canvas.width) {
-				ctx.canvas.width = width;
-			}
+            var rect = canvas.getBoundingClientRect(), // abs. size of element
+                scaleX = canvas.width / pixelRatio / rect.width, // relationship bitmap vs. element for X
+                scaleY = canvas.height / pixelRatio / rect.height; // relationship bitmap vs. element for Y
 
-			if (height != ctx.canvas.height) {
-				ctx.canvas.height = height;
-			}
+            let x = (evt.clientX - rect.left) * scaleX;
+            let y = (evt.clientY - rect.top) * scaleY;
+            // scale mouse coordinates after they have been adjusted to be relative to element
+            return {
+                x: x,
+                y: y,
+                radius
+            }
+        }
 
-			ctx.setTransform(pixelRatio, 0, 0, pixelRatio, 0, 0);
-			let sizes = getLanesSizes();
-			if (sizes && sizes.areaRect) {
-				const additionalOffset = options.stepPx;
-				newWidth = newWidth || 0;
-				// not less than current timeline position
-				let timelineGlobalPos = valToPx(timeLine.val, true);
-				let timelinePos = 0;
-				if (timelineGlobalPos > canvas.clientWidth) {
-					if (scrollMode == 'scrollBySelection') {
-						timelinePos = Math.floor(timelineGlobalPos + canvas.clientWidth + (options.stepPx || 0));
-					} else {
-						timelinePos = Math.floor(timelineGlobalPos + canvas.clientWidth / 1.5);
-					}
-				}
+        function rescale(scrollMode, newWidth, newHeight) {
+            var width = scrollContainer.clientWidth * pixelRatio;
+            var height = scrollContainer.clientHeight * pixelRatio;
+            if (width != ctx.canvas.width) {
+                ctx.canvas.width = width;
+            }
 
-				newWidth = Math.max(newWidth,
-					// keyframes size
-					sizes.areaRect.w + options.leftMarginPx + additionalOffset,
-					// not less than current scroll position
-					scrollContainer.scrollLeft + canvas.clientWidth,
-					timelinePos,
-				);
-				newWidth = Math.floor(newWidth) + "px";
+            if (height != ctx.canvas.height) {
+                ctx.canvas.height = height;
+            }
 
-				if (newWidth != size.style.minWidth) {
-					size.style.minWidth = newWidth
-				}
+            ctx.setTransform(pixelRatio, 0, 0, pixelRatio, 0, 0);
+            let sizes = getLanesSizes();
+            if (sizes && sizes.areaRect) {
+                const additionalOffset = options.stepPx;
+                newWidth = newWidth || 0;
+                // not less than current timeline position
+                let timelineGlobalPos = valToPx(timeLine.val, true);
+                let timelinePos = 0;
+                if (timelineGlobalPos > canvas.clientWidth) {
+                    if (scrollMode == 'scrollBySelection') {
+                        timelinePos = Math.floor(timelineGlobalPos + canvas.clientWidth + (options.stepPx || 0));
+                    } else {
+                        timelinePos = Math.floor(timelineGlobalPos + canvas.clientWidth / 1.5);
+                    }
+                }
 
-				newHeight = Math.max(Math.floor(sizes.areaRect.h + options.laneHeightPx * 4),
-					scrollContainer.scrollTop + canvas.clientHeight - 1,
-					Math.round(newHeight || 0));
+                newWidth = Math.max(newWidth,
+                    // keyframes size
+                    sizes.areaRect.w + options.leftMarginPx + additionalOffset,
+                    // not less than current scroll position
+                    scrollContainer.scrollLeft + canvas.clientWidth,
+                    timelinePos,
+                );
+                newWidth = Math.floor(newWidth) + "px";
 
-				let h = newHeight + "px";
-				if (size.style.minHeight != h) {
-					size.style.minHeight = h
-				}
-			}
-		}
+                if (newWidth != size.style.minWidth) {
+                    size.style.minWidth = newWidth
+                }
 
+                newHeight = Math.max(Math.floor(sizes.areaRect.h + options.laneHeightPx * 4),
+                    scrollContainer.scrollTop + canvas.clientHeight - 1,
+                    Math.round(newHeight || 0));
 
-		// Check whether we can drag something here.
-		function getDraggable(pos) {
-
-			// few extra pixels to select items:
-			let helperSelector = Math.max(2, pos.radius);
-			let draggable = null;
-			if (pos.y >= options.headerHeight && options.keyframesDraggable) {
-				iterateKeyframes(function (keyframe, keyframeIndex, lane, laneIndex) {
-					if (keyframe.draggable !== undefined) {
-						if (!keyframe.draggable) {
-							return;
-						}
-					}
-
-					let keyframePos = getKeyframePosition(keyframe, laneIndex);
-					if (keyframePos) {
-						const dist = getDistance(keyframePos.x, keyframePos.y, pos.x, pos.y);
-						if (dist <= keyframePos.size + helperSelector) {
-							if (!draggable) {
-								draggable = {
-									obj: keyframe,
-									pos: pos,
-									val: keyframe.val,
-									type: 'keyframe',
-									distance: dist
-								}
-							} else if (dist <= draggable.distance) {
-								draggable.obj = keyframe;
-								draggable.val = keyframe.val;
-							}
-						}
-					}
-				})
-
-				if (draggable) {
-					return draggable;
-				}
-
-				// Return keyframes lanes:
-				const lanesSizes = getLanesSizes();
-				if (options.keyframesLanesDraggable && lanesSizes) {
-					let foundOverlap = lanesSizes.sizes.find(function lanesSizesIterator(laneSize) {
-						if (!laneSize || !laneSize.keyframes) {
-							return false;
-						}
-
-						if (laneSize.lane.draggable !== undefined) {
-							if (!laneSize.lane.draggable) {
-								return;
-							}
-						}
-
-						let laneOverlaped = isOverlap(pos.x, pos.y, laneSize.keyframes);
-						return laneOverlaped;
-					});
-
-					if (foundOverlap) {
-						draggable = {
-							obj: foundOverlap,
-							pos: pos,
-							type: 'lane'
-						}
-
-						draggable.val = mousePosToVal(pos.x, true);
-
-						if (foundOverlap && foundOverlap.keyframes) {
-							if (foundOverlap.lane && foundOverlap.lane.keyframes) {
-								draggable.selectedItems = foundOverlap.lane.keyframes;
-							}
-
-							let firstVal = foundOverlap.keyframes.from;
-							let snapped = snapVal(firstVal);
-							// get snapped mouse pos based on the first keynode.
-							draggable.val += firstVal - snapped;
-						}
-
-						return draggable;
-					}
-				}
-			}
-
-			// Check whether we can drag timeline.
-			var timeLinePos = valToPx(timeLine.val);
-			let width = Math.max(((options.timelineThicknessPx || 1) * pixelRatio), options.timelineCapWidthPx * pixelRatio || 1) + helperSelector;
-			if (pos.x >= timeLinePos - width / 2 && pos.x <= timeLinePos + width / 2) {
-				return { obj: timeLine, type: "timeline" };
-			}
-		}
-
-		scrollContainer.addEventListener("wheel", function (event) {
-			if (controlKeyPressed(event)) {
-				event.preventDefault();
-				if (options.zoomSpeed > 0 && options.zoomSpeed <= 1) {
-					let mousePos = getMousePos(canvas, event);
-					let x = mousePos.x;
-					if (x <= 0)
-						x = 0;
-					let val = pxToVal(scrollContainer.scrollLeft + x, false);
-					let diff = canvas.clientWidth / x;
-
-					let zoom = sign(event.deltaY) * options.zoom * options.zoomSpeed;
-					options.zoom += zoom;
-					if (options.zoom > options.zoomMax) {
-						options.zoom = options.zoomMax;
-					}
-					if (options.zoom < options.zoomMin) {
-						options.zoom = options.zoomMin;
-					}
-					let zoomCenter = valToPx(val, true);
-					let newScrollLeft = Math.round(zoomCenter - canvas.clientWidth / diff);
-					if (newScrollLeft <= 0) {
-						newScrollLeft = 0;
-					}
-
-					rescale('zoom', newScrollLeft + canvas.clientWidth);
-					if (scrollContainer.scrollLeft != newScrollLeft) {
-						scrollContainer.scrollLeft = newScrollLeft;
-						// Scroll event will redraw the screen.
-					}
-
-					redraw();
-				}
-			}
-		});
-
-		if (scrollContainer) {
-			scrollContainer.addEventListener('scroll', function (args) {
-				var left = scrollContainer.scrollLeft + 'px';
-				if (canvas.style.left !== left) {
-					canvas.style.left = left;
-				}
-
-				var top = scrollContainer.scrollTop + 'px';
-				if (top !== canvas.style.top) {
-					canvas.style.top = top;
-				}
-
-				if (scrollingTimeRef) {
-					clearTimeout(scrollingTimeRef);
-					scrollingTimeRef = null;
-				}
-
-				// Set a timeout to run event 'scrolling end'.
-				scrollingTimeRef = setTimeout(function () {
-					if (!isPanStarted) {
-						if (scrollingTimeRef) {
-							clearTimeout(scrollingTimeRef);
-							scrollingTimeRef = null;
-						}
-
-						rescale();
-						redraw();
-					}
-
-				}, 500);
-
-				redraw();
-				let scrollData = {
-					args: args,
-					scrollLeft: scrollContainer.scrollLeft,
-					scrollTop: scrollContainer.scrollTop,
-					scrollHeight: scrollContainer.scrollHeight,
-					scrollWidth: scrollContainer.scrollWidth
-				};
-
-				emit('scroll', scrollData);
-			});
-		}
-
-		window.addEventListener('blur', function () {
-			cleanUpSelection();
-		}, false);
-
-		window.addEventListener('resize', function () {
-			// Rescale and redraw
-			rescale();
-			redraw();
-		}, false);
-
-		document.addEventListener('keydown', (function (e) {
-			// ctrl + a. Select all keyframes
-			if (e.which === 65 && controlKeyPressed(e)) {
-				performSelection(true);
-				e.preventDefault();
-				return false;
-			}
-		}));
-
-		canvas.addEventListener('touchstart', function (args) {
-			onMouseDown(args);
-		}, false);
-
-		canvas.addEventListener('mousedown', function (args) {
-			onMouseDown(args);
-		}, false);
+                let h = newHeight + "px";
+                if (size.style.minHeight != h) {
+                    size.style.minHeight = h
+                }
+            }
+        }
 
 
-		function onMouseDown(args) {
+        // Check whether we can drag something here.
+        function getDraggable(pos) {
+
+            // few extra pixels to select items:
+            let helperSelector = Math.max(2, pos.radius);
+            let draggable = null;
+            if (pos.y >= options.headerHeight && options.keyframesDraggable) {
+                iterateKeyframes(function (keyframe, keyframeIndex, lane, laneIndex) {
+                    if (keyframe.draggable !== undefined) {
+                        if (!keyframe.draggable) {
+                            return;
+                        }
+                    }
+
+                    let keyframePos = getKeyframePosition(keyframe, laneIndex);
+                    if (keyframePos) {
+                        const dist = getDistance(keyframePos.x, keyframePos.y, pos.x, pos.y);
+                        if (dist <= keyframePos.size + helperSelector) {
+                            if (!draggable) {
+                                draggable = {
+                                    obj: keyframe,
+                                    pos: pos,
+                                    val: keyframe.val,
+                                    type: 'keyframe',
+                                    distance: dist
+                                }
+                            } else if (dist <= draggable.distance) {
+                                draggable.obj = keyframe;
+                                draggable.val = keyframe.val;
+                            }
+                        }
+                    }
+                })
+
+                if (draggable) {
+                    return draggable;
+                }
+
+                // Return keyframes lanes:
+                const lanesSizes = getLanesSizes();
+                if (options.keyframesLanesDraggable && lanesSizes) {
+                    let foundOverlap = lanesSizes.sizes.find(function lanesSizesIterator(laneSize) {
+                        if (!laneSize || !laneSize.keyframes) {
+                            return false;
+                        }
+
+                        if (laneSize.lane.draggable !== undefined) {
+                            if (!laneSize.lane.draggable) {
+                                return;
+                            }
+                        }
+
+                        let laneOverlaped = isOverlap(pos.x, pos.y, laneSize.keyframes);
+                        return laneOverlaped;
+                    });
+
+                    if (foundOverlap) {
+                        draggable = {
+                            obj: foundOverlap,
+                            pos: pos,
+                            type: 'lane'
+                        }
+
+                        draggable.val = mousePosToVal(pos.x, true);
+
+                        if (foundOverlap && foundOverlap.keyframes) {
+                            if (foundOverlap.lane && foundOverlap.lane.keyframes) {
+                                draggable.selectedItems = foundOverlap.lane.keyframes;
+                            }
+
+                            let firstVal = foundOverlap.keyframes.from;
+                            let snapped = snapVal(firstVal);
+                            // get snapped mouse pos based on the first keynode.
+                            draggable.val += firstVal - snapped;
+                        }
+
+                        return draggable;
+                    }
+                }
+            }
+
+            // Check whether we can drag timeline.
+            var timeLinePos = valToPx(timeLine.val);
+            let width = Math.max(((options.timelineThicknessPx || 1) * pixelRatio), options.timelineCapWidthPx * pixelRatio || 1) + helperSelector;
+            if (pos.x >= timeLinePos - width / 2 && pos.x <= timeLinePos + width / 2) {
+                return {
+                    obj: timeLine,
+                    type: "timeline"
+                };
+            }
+        }
+        this.getDraggable = getDraggable;
+
+        scrollContainer.addEventListener("wheel", function (event) {
+            if (controlKeyPressed(event)) {
+                event.preventDefault();
+                if (options.zoomSpeed > 0 && options.zoomSpeed <= 1) {
+                    let mousePos = getMousePos(canvas, event);
+                    let x = mousePos.x;
+                    if (x <= 0)
+                        x = 0;
+                    var val = pxToVal(scrollContainer.scrollLeft + x, false);
+                    let diff = canvas.clientWidth / x;
+
+                    let zoom = sign(event.deltaY) * options.zoom * options.zoomSpeed;
+                    options.zoom += zoom;
+                    if (options.zoom > options.zoomMax) {
+                        options.zoom = options.zoomMax;
+                    }
+                    if (options.zoom < options.zoomMin) {
+                        options.zoom = options.zoomMin;
+                    }
+                    let zoomCenter = valToPx(val, true);
+                    let newScrollLeft = Math.round(zoomCenter - canvas.clientWidth / diff);
+                    if (newScrollLeft <= 0) {
+                        newScrollLeft = 0;
+                    }
+
+                    rescale('zoom', newScrollLeft + canvas.clientWidth);
+                    if (scrollContainer.scrollLeft != newScrollLeft) {
+                        scrollContainer.scrollLeft = newScrollLeft;
+                        // Scroll event will redraw the screen.
+                    }
+
+                    redraw();
+                }
+            }
+        });
+
+        if (scrollContainer) {
+            scrollContainer.addEventListener('scroll', function (args) {
+                var left = scrollContainer.scrollLeft + 'px';
+                if (canvas.style.left !== left) {
+                    canvas.style.left = left;
+                }
+
+                var top = scrollContainer.scrollTop + 'px';
+                if (top !== canvas.style.top) {
+                    canvas.style.top = top;
+                }
+
+                if (scrollingTimeRef) {
+                    clearTimeout(scrollingTimeRef);
+                    scrollingTimeRef = null;
+                }
+
+                // Set a timeout to run event 'scrolling end'.
+                scrollingTimeRef = setTimeout(function () {
+                    if (!isPanStarted) {
+                        if (scrollingTimeRef) {
+                            clearTimeout(scrollingTimeRef);
+                            scrollingTimeRef = null;
+                        }
+
+                        rescale();
+                        redraw();
+                    }
+
+                }, 500);
+
+                redraw();
+                let scrollData = {
+                    args: args,
+                    scrollLeft: scrollContainer.scrollLeft,
+                    scrollTop: scrollContainer.scrollTop,
+                    scrollHeight: scrollContainer.scrollHeight,
+                    scrollWidth: scrollContainer.scrollWidth
+                };
+
+                emit('scroll', scrollData);
+            });
+        }
+
+        window.addEventListener('blur', function () {
+            cleanUpSelection();
+        }, false);
+
+        window.addEventListener('resize', function () {
+            // Rescale and redraw
+            rescale();
+            redraw();
+        }, false);
+
+        document.addEventListener('keydown', (function (e) {
+            // ctrl + a. Select all keyframes
+            if (e.which === 65 && controlKeyPressed(e)) {
+                performSelection(true);
+                e.preventDefault();
+                return false;
+            }
+        }));
+
+        canvas.addEventListener('touchstart', function (args) {
+            onMouseDown(args);
+        }, false);
+
+        canvas.addEventListener('mousedown', function (args) {
+            onMouseDown(args);
+        }, false);
+
+
+        function onMouseDown(args) {
+
             var isDoubleClick = Date.now() - lastClickTime < doubleClickTimeoutMs;
             lastClickTime = Date.now();
 
-			// Prevent drag of the canvas if canvas is selected as text:
-			clearBrowserSelection();
-			startPos = trackMousePos(canvas, args);
+            // Prevent drag of the canvas if canvas is selected as text:
+            clearBrowserSelection();
+            startPos = trackMousePos(canvas, args);
             startPos.snapVal = snapVal(startPos.val);
 
             if (isDoubleClick) {
@@ -603,1233 +598,1269 @@
 
             emit('mousedown', startPos);
 
-			clickDurarion = new Date();
-			currentPos = startPos;
-			drag = getDraggable(currentPos);
-			// Select keyframes on mouse down
-			if (drag) {
-				if (drag.type == 'keyframe') {
-					drag.startedWithCtrl = controlKeyPressed(args);
-					drag.startedWithShiftKey = args.shiftKey;
-					// get all related selected keyframes if we are selecting one.
-					if (!drag.obj.selected && !controlKeyPressed(args) && !args.shiftKey) {
-						performSelection(true, drag.obj, 'keyframe');
-					}
+            clickDurarion = new Date();
+            currentPos = startPos;
+            drag = getDraggable(currentPos);
+            // Select keyframes on mouse down
+            if (drag) {
+                if (drag.type == 'keyframe') {
+                    drag.startedWithCtrl = controlKeyPressed(args);
+                    drag.startedWithShiftKey = args.shiftKey;
+                    // get all related selected keyframes if we are selecting one.
+                    if (!drag.obj.selected && !controlKeyPressed(args) && !args.shiftKey) {
+                        performSelection(true, drag.obj, 'keyframe');
+                    }
 
-					drag.selectedItems = getSelectedKeyframes();
-				}
-			}
+                    drag.selectedItems = getSelectedKeyframes();
+                }
+            }
 
-			redraw();
-		}
+            redraw();
+        }
 
 
-		let lastUseArgs = null;
-		window.addEventListener('mousemove', function (args) {
-			lastUseArgs = args;
-			onMouseMove(args);
-		}, false);
+        let lastUseArgs = null;
+        window.addEventListener('mousemove', function (args) {
+            lastUseArgs = args;
+            onMouseMove(args);
+        }, false);
 
-		window.addEventListener('touchmove', function (args) {
-			lastUseArgs = args;
-			onMouseMove(args);
-		}, false);
+        window.addEventListener('touchmove', function (args) {
+            lastUseArgs = args;
+            onMouseMove(args);
+        }, false);
 
-		function setKeyframePos(keyframe, toSet) {
-			toSet = Math.floor(toSet);
-			if (keyframe && keyframe.val != toSet) {
-				keyframe.val = toSet;
-				return true;
-			}
+        function setKeyframePos(keyframe, toSet) {
+            toSet = Math.floor(toSet);
+            if (keyframe && keyframe.val != toSet) {
+                keyframe.val = toSet;
+                return true;
+            }
 
-			return false;
-		}
+            return false;
+        }
 
-		function onMouseMove(args) {
-			if (!args) {
-				args = lastUseArgs;
-			}
+        function onMouseMove(args) {
+            if (!args) {
+                args = lastUseArgs;
+            }
 
-			if (!args) {
-				return;
-			}
+            if (!args) {
+                return;
+            }
 
-			let isTouch = (args.changedTouches && args.changedTouches.length > 0);
+            let isTouch = (args.changedTouches && args.changedTouches.length > 0);
 
-			currentPos = trackMousePos(canvas, args);
-			if (!isPanStarted && selectionRect && checkClickDurationOver()) {
-				selectionRect.enabled = true;
-			}
+            currentPos = trackMousePos(canvas, args);
+            if (!isPanStarted && selectionRect && checkClickDurationOver()) {
+                selectionRect.enabled = true;
+            }
 
-			if (startPos) {
-				if (args.buttons == 1 || isTouch) {
-					let isChanged = false;
-					if (drag && drag.obj && !drag.startedWithCtrl) {
-						let convertedVal = mousePosToVal(currentPos.x, true);
-						//redraw();
-						if (drag.type == 'timeline') {
-							isChanged |= setTimeInternal(convertedVal, 'user');
-						} else if ((drag.type == 'keyframe' || drag.type == 'lane') && drag.selectedItems) {
-							let offset = Math.floor(convertedVal - drag.val);
-							if (Math.abs(offset) > 0) {
-								// dont allow to move less than zero.
-								drag.selectedItems.forEach(function (p) {
-									if (options.snapAllKeyframesOnMove) {
-										let toSet = snapVal(p.val);
-										isChanged |= setKeyframePos(p, toSet);
-									}
+            if (startPos) {
+                if (args.buttons == 1 || isTouch) {
+                    let isChanged = false;
+                    if (drag && drag.obj && !drag.startedWithCtrl) {
+                        let convertedVal = mousePosToVal(currentPos.x, true);
+                        //redraw();
+                        if (drag.type == 'timeline') {
+                            isChanged |= setTimeInternal(convertedVal, 'user');
+                        } else if ((drag.type == 'keyframe' || drag.type == 'lane') && drag.selectedItems) {
+                            let offset = Math.floor(convertedVal - drag.val);
+                            if (Math.abs(offset) > 0) {
+                                // dont allow to move less than zero.
+                                drag.selectedItems.forEach(function (p) {
+                                    if (options.snapAllKeyframesOnMove) {
+                                        let toSet = snapVal(p.val);
+                                        isChanged |= setKeyframePos(p, toSet);
+                                    }
 
-									let newPostion = p.val + offset;
-									if (newPostion < 0) {
-										offset = -p.val;
-									}
-								});
+                                    let newPostion = p.val + offset;
+                                    if (newPostion < 0) {
+                                        offset = -p.val;
+                                    }
+                                });
 
-								if (Math.abs(offset) > 0) {
-									// dont allow to move less than zero.
-									drag.selectedItems.forEach(function (p) {
-										let toSet = p.val + offset;
-										isChanged |= setKeyframePos(p, toSet);
-									});
+                                if (Math.abs(offset) > 0) {
+                                    // dont allow to move less than zero.
+                                    drag.selectedItems.forEach(function (p) {
+                                        let toSet = p.val + offset;
+                                        isChanged |= setKeyframePos(p, toSet);
+                                    });
 
-								}
+                                }
 
-								if (isChanged) {
-									if (!drag.changed) {
-										emit('dragStarted', { keyframes: drag.selectedItems });
-									}
+                                if (isChanged) {
+                                    if (!drag.changed) {
+                                        emit('dragStarted', {
+                                            keyframes: drag.selectedItems
+                                        });
+                                    }
 
-									drag.changed = true;
+                                    drag.changed = true;
 
-									drag.val += offset;
-									emit('drag', { keyframes: drag.selectedItems });
-								}
-							}
-						}
+                                    drag.val += offset;
+                                    emit('drag', {
+                                        keyframes: drag.selectedItems
+                                    });
+                                }
+                            }
+                        }
 
-					}
+                    }
 
-					if (isPanMode && !drag) {
-						isPanStarted = true;
-						// Track scroll by drag.
-						scrollByPan(startPos, currentPos);
-					} else {
-						// Track scroll by mouse or touch out of the area.
-						scrollBySelectionOutOfBounds(currentPos);
-					}
-					redraw();
-				}
-				else {
-					// Fallback. Cancel mouse move when focus was lost and mouse down is still counted.
-					cleanUpSelection();
-					redraw();
-				}
-			} else if (!isTouch) {
-				let draggable = getDraggable(currentPos);
-				setCursor('default');
-				if (draggable) {
-					let cursor = null;
-					if (draggable.obj) {
-						cursor = draggable.obj.cursor;
-					}
+                    if (isPanMode && !drag) {
+                        isPanStarted = true;
+                        // Track scroll by drag.
+                        scrollByPan(startPos, currentPos);
+                    } else {
+                        // Track scroll by mouse or touch out of the area.
+                        scrollBySelectionOutOfBounds(currentPos);
+                    }
+                    redraw();
+                } else {
+                    // Fallback. Cancel mouse move when focus was lost and mouse down is still counted.
+                    cleanUpSelection();
+                    redraw();
+                }
+            } else if (!isTouch) {
+                let draggable = getDraggable(currentPos);
+                setCursor('default');
+                if (draggable) {
+                    let cursor = null;
+                    if (draggable.obj) {
+                        cursor = draggable.obj.cursor;
+                    }
 
-					if (draggable.type == 'lane') {
-						cursor = cursor || "ew-resize";
-					}
-					else if (draggable.type == 'keyframe') {
-						cursor = cursor || "pointer";
-					}
-					else {
-						cursor = cursor || "ew-resize";
-					}
+                    if (draggable.type == 'lane') {
+                        cursor = cursor || "ew-resize";
+                    } else if (draggable.type == 'keyframe') {
+                        cursor = cursor || "pointer";
+                    } else {
+                        cursor = cursor || "ew-resize";
+                    }
 
-					if (cursor) {
-						setCursor(cursor);
-					}
-				}
-			}
+                    if (cursor) {
+                        setCursor(cursor);
+                    }
+                }
+            }
 
-			if (isTouch) {
-				args.preventDefault();
-			}
-		}
+            if (isTouch) {
+                args.preventDefault();
+            }
+        }
 
-		function setCursor(cursor) {
-			if (canvas.style.cursor != cursor) {
-				canvas.style.cursor = cursor;
-			}
-		}
+        function setCursor(cursor) {
+            if (canvas.style.cursor != cursor) {
+                canvas.style.cursor = cursor;
+            }
+        }
 
-		window.addEventListener('mouseup', function (args) {
-			onMouseUp(args);
-		}, false);
+        window.addEventListener('mouseup', function (args) {
+            onMouseUp(args);
+        }, false);
 
-		window.addEventListener('touchend', function (args) {
-			onMouseUp(args);
-		}, false);
+        window.addEventListener('touchend', function (args) {
+            onMouseUp(args);
+        }, false);
 
-		function onMouseUp(args) {
-			if (startPos) {
-				//window.releaseCapture();
-				let pos = trackMousePos(canvas, args);
+        function onMouseUp(args) {
+            if (startPos) {
+                //window.releaseCapture();
+                let pos = trackMousePos(canvas, args);
 
-				// Click detection.
-				if (selectionRect && selectionRect.h <= 2 && selectionRect.w <= 2 ||
-					!checkClickDurationOver() ||
-					(drag && drag.startedWithCtrl) ||
-					(drag && drag.startedWithShiftKey)) {
-					performClick(pos, args, drag);
-				} else if (!drag && selectionRect && selectionRect.enabled) {
-					performSelection(true, selectionRect, 'rectangle', args.shiftKey);
-				}
+                // Click detection.
+                if (selectionRect && selectionRect.h <= 2 && selectionRect.w <= 2 ||
+                    !checkClickDurationOver() ||
+                    (drag && drag.startedWithCtrl) ||
+                    (drag && drag.startedWithShiftKey)) {
+                    performClick(pos, args, drag);
+                } else if (!drag && selectionRect && selectionRect.enabled) {
+                    performSelection(true, selectionRect, 'rectangle', args.shiftKey);
+                }
 
-				cleanUpSelection();
-				redraw();
-			}
-		}
+                cleanUpSelection();
+                redraw();
+            }
+        }
 
-		function performClick(pos, args, drag) {
-			let isChanged = false;
-			if (drag && drag.type == 'keyframe') {
-				let isSelected = true;
-				if ((drag.startedWithCtrl && controlKeyPressed(args)) || (drag.startedWithShiftKey && args.shiftKey)) {
+        function performClick(pos, args, drag) {
+            let isChanged = false;
+            if (drag && drag.type == 'keyframe') {
+                let isSelected = true;
+                if ((drag.startedWithCtrl && controlKeyPressed(args)) || (drag.startedWithShiftKey && args.shiftKey)) {
                     if (controlKeyPressed(args)) {
-						isSelected = !drag.obj.selected
-					}
-				}
-				// Reverse selected keyframe selection by a click:
-				isChanged |= performSelection(isSelected, drag.obj, 'keyframe', controlKeyPressed(args) || args.shiftKey);
-
-				if (args.shiftKey) {
-					// change timeline pos:
-					let convertedVal = mousePosToVal(pos.x, true);
-					// Set current timeline position if it's not a drag or selection rect small or fast click.
-					isChanged |= setTimeInternal(convertedVal, 'user');
-				}
-			}
-			else {
-				// deselect keyframes if any:
-				isChanged |= performSelection(false);
-
-				// change timeline pos:
-				let convertedVal = mousePosToVal(pos.x, true);
-				// Set current timeline position if it's not a drag or selection rect small or fast click.
-				isChanged |= setTimeInternal(convertedVal, 'user');
-			}
-
-			return isChanged;
-		}
-
-		function setPanMode(value) {
-			if (isPanMode != value) {
-				isPanMode = value;
-				// Awoid any conflicts with other modes:
-				cleanUpSelection();
-			}
-		}
-
-		this.setPanMode = setPanMode;
-		function getSelectedKeyframes() {
-			selectedKeyframes.length = 0;
-			iterateKeyframes(function selectionIterator(keyframe) {
-				if (keyframe && keyframe.selected) {
-					selectedKeyframes.push(keyframe);
-				}
-			});
-
-			return selectedKeyframes;
-		}
-
-
-		/**
-		 * Do the selection.
-		 * @param {boolean} isSelected 
-		 * @param {object} selector can be retangle or keyframe object.
-		 * @param {string} mode selector mode. keyframe | rectrangle | all  
-		 * @param {boolean} ignoreOthers value indicating whether all other object should be reversed. 
-		 * @return isChanged
-		 */
-		function performSelection(isSelected, selector, mode, ignoreOthers) {
-			if (isSelected === undefined) {
-				isSelected = true;
-			}
-
-			let deselectionMode = false;
-			if (!mode) {
-				mode = 'all';
-			}
-
-			if (mode == 'all') {
-				if (!isSelected) {
-					isSelected = false;
-				}
-
-				deselectionMode = isSelected;
-			}
-
-			selectedKeyframes.length = 0;
-			let isChanged = true;
-
-			iterateKeyframes(function selectionIterator(keyframe, keyframeIndex, lane, laneIndex) {
-				let keyframePos = getKeyframePosition(keyframe, laneIndex);
-				if (keyframePos) {
-					if ((mode == 'keyframe' && selector == keyframe) ||
-						(mode == 'rectangle' && selector && isOverlap(keyframePos.x, keyframePos.y, selector))) {
-						if (keyframe.selected != isSelected) {
-							keyframe.selected = isSelected;
-							isChanged = true;
-						}
-
-						if (keyframe.selected) {
-							selectedKeyframes.push(keyframe);
-						}
-					} else {
-						// Deselect all other keyframes.
-						if (!ignoreOthers && keyframe.selected != deselectionMode) {
-							keyframe.selected = deselectionMode;
-							isChanged = deselectionMode;
-						}
-					}
-				}
-			});
-
-			if (isChanged) {
-				onKeyframesSelected(selectedKeyframes);
-			}
-
-			return isChanged;
-		}
-
-		function iterateKeyframes(callback) {
-			if (!lanes || !lanes.forEach || lanes.length <= 0) {
-				return false;
-			}
-
-			let nextLane = false;
-			lanes.filter(p => p && !p.hidden).forEach(function lanesIterator(lane, index) {
-				if (!lane || !lane.keyframes || !lane.keyframes.forEach || lane.keyframes.length <= 0) {
-					return;
-				}
-
-				nextLane = true;
-				lane.keyframes.filter(p => p && !p.hidden).forEach(function keyframesIterator(keyframe, keyframeIndex) {
-					if (callback && keyframe) {
-						callback(keyframe, keyframeIndex, lane, index, nextLane);
-					}
-
-					nextLane = false;
-				});
-			});
-		}
-
-		function trackMousePos(canvas, mouseArgs) {
-			const pos = getMousePos(canvas, mouseArgs);
-			pos.scrollLeft = scrollContainer.scrollLeft;
-			pos.scrollTop = scrollContainer.scrollTop;
-			pos.val = pxToVal(pos.x + pos.scrollLeft);
-
-			if (startPos) {
-				if (!selectionRect) {
-					selectionRect = {};
-				}
-
-				// get the pos with the virtualization:
-				let x = Math.floor(startPos.x + (startPos.scrollLeft - pos.scrollLeft));
-				let y = Math.floor(startPos.y + (startPos.scrollTop - pos.scrollTop));
-				selectionRect.x = Math.min(x, pos.x);
-				selectionRect.y = Math.min(y, pos.y);
-				selectionRect.w = Math.max(x, pos.x) - selectionRect.x;
-				selectionRect.h = Math.max(y, pos.y) - selectionRect.y;
-			}
-
-			return pos;
-		}
-
-		function cleanUpSelection() {
-			if (drag && drag.changed) {
-				emit('dragFinished', { keyframes: drag.selectedItems });
-			}
-
-			startPos = null;
-			drag = null;
-			selectionRect = null;
-			clickDurarion = null;
-			isPanStarted = false;
-			clearMoveInterval();
-		}
-
-		function checkClickDurationOver() {
-			// Duration before the selection can be tracked.
-			if ((clickDurarion && new Date() - clickDurarion > clickDetectionMs)) {
-				return true;
-			}
-
-			return false;
-		}
-
-		//stepsCanFit
-		rescale();
-
-		/**
-		 * Automatically move canvas when selection and mouse over the bounds.
-		 */
-		function startAutoScrollInterval() {
-			if (!intervalReference) {
-				// Repeat move calls to
-				intervalReference = setInterval(function () {
-					onMouseMove();
-				}, 50);
-			}
-		}
-
-		function clearMoveInterval() {
-			if (intervalReference) {
-				clearInterval(intervalReference);
-				intervalReference = null;
-			}
-
-			lastCallDate = null;
-		}
-
-		function checkUpdateSpeedIsFast() {
-			// Dont update too often.
-			if (lastCallDate && new Date() - lastCallDate <= 10) {
-				return true;
-			}
-
-			lastCallDate = new Date();
-			return false;
-		}
-
-
-		function scrollByPan(start, pos) {
-			if (!start || !pos) {
-				return;
-			}
-
-			let newTop = Math.round(start.y - pos.y);
-			let offsetX = Math.round(start.x - pos.x);
-			let newLeft = start.scrollLeft + offsetX;
-
-			if (offsetX > 0) {
-				rescale(newLeft + canvas.clientWidth);
-			}
-
-			if (offsetX > 0 && newLeft + canvas.clientWidth >= scrollContainer.scrollWidth - 5) {
-				scrollContainer.scrollLeft = scrollContainer.scrollWidth;
-			}
-			else {
-				scrollContainer.scrollLeft = newLeft;
-			}
-			scrollContainer.scrollTop = newTop;
-
-		}
-
-		function scrollBySelectionOutOfBounds(pos) {
-			let x = pos.x;
-			let y = pos.y;
-			let isChanged = false;
-			let speedX = 0;
-			let speedY = 0;
-			let isLeft = x <= 0;
-			let isRight = x >= canvas.clientWidth;
-			let isTop = y <= 0;
-			let isBottom = y >= canvas.clientHeight;
-			let newWidth = null;
-			let newHeight = null;
-			if (isLeft || isRight || isTop || isBottom) {
-				// Auto move init
-				startAutoScrollInterval();
-
-				if (checkUpdateSpeedIsFast()) {
-					return;
-				}
-
-				let scrollSpeedMultiplier = (isNaN(options.scrollByDragSpeed) ? 1 : options.scrollByDragSpeed);
-				if (isLeft) {
-					// Get normilized speed.
-					speedX = -getDistance(x, 0) * scrollSpeedMultiplier
-				} else if (isRight) {
-					// Get normalized speed: 
-					speedX = getDistance(x, canvas.clientWidth) * scrollSpeedMultiplier;
-					newWidth = scrollContainer.scrollLeft + canvas.clientWidth + speedX;
-				}
-
-				if (isTop) {
-					// Get normilized speed.
-					speedY = -getDistance(x, 0) * scrollSpeedMultiplier / 4;
-				} else if (isBottom) {
-					// Get normalized speed: 
-					speedY = getDistance(x, canvas.clientHeight) * scrollSpeedMultiplier / 4;
-					newHeight = scrollContainer.scrollTop + canvas.clientHeight;
-				}
-			}
-			else {
-				clearMoveInterval();
-			}
-
-			if (newWidth || newHeight) {
-				rescale('scrollBySelection', newWidth, newHeight);
-			}
-
-			if (Math.abs(speedX) > 0) {
-				scrollContainer.scrollLeft += speedX;
-				isChanged = true;
-			}
-
-			if (Math.abs(speedY) > 0) {
-				scrollContainer.scrollTop += speedY;
-				isChanged = true;
-			}
-
-			return isChanged;
-		}
-
-		// Find ms from the the px coordinates
-		function pxToVal(coords, globalCoords) {
-			if (!globalCoords) {
-				coords -= options.leftMarginPx;
-			}
-			var ms = coords / options.stepPx * options.zoom;
-			return ms;
-		}
-
-		// convert 
-		function valToPx(ms, globalCoords) {
-			// Respect current scroll container offset. (virtualization)
-			if (!globalCoords) {
-				var x = scrollContainer.scrollLeft;
-				ms -= pxToVal(x);
-			}
-
-			return (ms * options.stepPx / options.zoom);
-		}
-
-		function snapVal(ms) {
-			// Apply snap to steps if enabled.
-			if (options.snapsPerSeconds && options.snapEnabled) {
-				var stopsPerPixel = (1000 / options.snapsPerSeconds);
-				let step = ms / stopsPerPixel;
-				var stepsFit = Math.round(step);
-				ms = Math.round(stepsFit * stopsPerPixel);
-			}
-
-			if (ms < 0) {
-				ms = 0;
-			}
-
-			return ms;
-		}
-
-		function mousePosToVal(x, snapEnabled) {
-			let convertedVal = pxToVal(scrollContainer.scrollLeft + Math.min(x, canvas.clientWidth));
-			convertedVal = Math.round(convertedVal);
-			if (snapEnabled) {
-				convertedVal = snapVal(convertedVal);
-			}
-
-			return convertedVal;
-		}
-
-		function findGoodStep(originaStep, divisionCheck) {
-			var step = originaStep;
-			var lastDistance = null;
-			var pow = getPowArgument(originaStep);
-			for (var i = 0; i < denominators.length; i++) {
-				var denominator = denominators[i];
-				var calculatedStep = denominator * Math.pow(10, pow);
-				if (divisionCheck && (divisionCheck % calculatedStep) != 0) {
-					continue;
-				}
-				var distance = getDistance(originaStep, calculatedStep);
-
-				if (distance == 0 || (distance <= 0.1 && pow > 0)) {
-					lastDistance = distance;
-					step = calculatedStep;
-					break;
-				} else if (!lastDistance || lastDistance > distance) {
-					lastDistance = distance;
-					step = calculatedStep;
-				}
-			}
-
-			return step;
-		}
-
-		function drawTicks() {
-			ctx.save();
-
-			var areaWidth = scrollContainer.scrollWidth - options.leftMarginPx;
-			var from = pxToVal(0);
-			var to = pxToVal(areaWidth);
-			var dist = getDistance(from, to);
-			// normalize step.			
-			var stepsCanFit = areaWidth / options.stepPx;
-			let realStep = dist / stepsCanFit;
-			// Find the nearest 'beautiful' step for a gauge. This step should be devided by 1/2/5!
-			//let step = realStep;
-			let step = findGoodStep(realStep);
-			var goodStepDistancePx = areaWidth / (dist / step);
-			var smallStepsCanFit = goodStepDistancePx / options.stepSmallPx;
-			var realSmallStep = step / smallStepsCanFit;
-			var smallStep = findGoodStep(realSmallStep, step);
-			if (step % smallStep != 0) {
-				smallStep = realSmallStep;
-			}
-			// filter to draw only visible
-			var visibleFrom = pxToVal(scrollContainer.scrollLeft + options.leftMarginPx);
-			var visibleTo = pxToVal(scrollContainer.scrollLeft + scrollContainer.clientWidth);
-			// Find beautiful start point:
-			from = Math.floor(visibleFrom / step) * step;
-
-			// Find a beautiful end point:
-			to = Math.ceil(visibleTo / step) * step + step;
-
-			let lastTextX = null;
-			for (var i = from; i <= to; i += step) {
-				var pos = valToPx(i);
-				var sharpPos = getSharp(Math.round(pos));
-				ctx.save();
-				ctx.beginPath();
-				ctx.setLineDash([4]);
-				ctx.lineWidth = pixelRatio;
-				ctx.strokeStyle = options.tickColor;
-				drawLine(ctx, sharpPos, (options.headerHeight || 0) / 2, sharpPos, canvas.clientHeight);
-				ctx.stroke();
-
-				ctx.fillStyle = options.labelsColor;
-				if (options.ticksFont) {
-					ctx.font = options.ticksFont;
-				}
-
-				var text = msToHMS(i)
-				var textSize = ctx.measureText(text);
-
-				let textX = sharpPos - textSize.width / 2;
-				// skip text render if there is no space for it.
-				if (isNaN(lastTextX) || lastTextX <= textX) {
-
-					lastTextX = textX + textSize.width;
-					ctx.fillText(text, textX, 10);
-				}
-
-				ctx.restore();
-				// Draw small steps
-				for (let x = i + smallStep; x < i + step; x += smallStep) {
-					var nextPos = valToPx(x);
-					var nextSharpPos = getSharp(Math.floor(nextPos));
-					ctx.beginPath();
-					ctx.lineWidth = pixelRatio;
-					ctx.strokeStyle = options.tickColor;
-					drawLine(ctx, nextSharpPos, (options.headerHeight || 0) / 1.3, nextSharpPos, options.headerHeight);
-					ctx.stroke();
-				}
-			}
-
-			ctx.restore();
-		}
-
-		function getLanesSizes() {
-			let toReturn = {
-				sizes: [],
-				areaRect: {
-					x: 0,
-					y: 0,
-					w: 0,
-					h: 0,
-					from: null,
-					to: null
-				}
-			}
-
-			if (!options.laneHeightPx) {
-				console.log('laneHeightPx should be set.');
-				return toReturn;
-			}
-
-			if (!lanes || !lanes.forEach || lanes.length <= 0) {
-				return toReturn;
-			}
-
-			const areaRect = toReturn.areaRect;
-
-			lanes.filter(p => p && !p.hidden).forEach(function lanesIterator(lane, index) {
-				if (!lane) {
-					return;
-				}
-
-				// draw with scroll virtualization:
-				var globalLaneY = getLanePosition(index);
-				var laneY = globalLaneY - scrollContainer.scrollTop;
-				if (index == 0) {
-					areaRect.y = laneY;
-				}
-
-				areaRect.h = Math.max(globalLaneY + options.laneHeightPx, areaRect.h);
-
-				var laneSize = {
-					x: 0,
-					y: laneY,
-					w: canvas.clientWidth,
-					h: options.laneHeightPx,
-					clientWidth: canvas.clientWidth,
-					clientHeight: canvas.clientHeight,
-					lane: lane,
-					index: index,
-					keyframes: {
-						from: null,
-						to: null,
-						count: lane.keyframes ? lane.keyframes.length : 0,
-					}
-				};
-
-				// get the bounds on a canvas. used instead of the clip (clip is slow)
-				laneSize.bounds = cutBounds({ x: laneSize.x, y: laneSize.y, w: laneSize.w, h: laneSize.h });
-
-				toReturn.sizes.push(laneSize);
-				let size = laneSize.keyframes;
-
-				if (!lane.keyframes || !lane.keyframes.forEach || lane.keyframes.length <= 0) {
-					return;
-				}
-
-				// Get min and max ms to draw keyframe lane:
-				lane.keyframes.forEach(function keyframesIterator(keyframe) {
-					let val = keyframe.val;
-
-					if (size && keyframe && !isNaN(val)) {
-						size.from = size.from == null ? val : Math.min(val, size.from);
-						size.to = size.to == null ? val : Math.max(val, size.to);
-					}
-				});
-
-				// get absolute min and max:
-				areaRect.from = areaRect.from == null ? size.from : Math.min(size.from, areaRect.from);
-				areaRect.to = areaRect.to == null ? size.to : Math.max(size.to, areaRect.to);
-
-				// get keyframes lane size
-				if (laneSize && !isNaN(size.from) && !isNaN(size.to)) {
-					// draw keyframes lane.
-					var fromPos = getSharp(valToPx(size.from))
-					var toPos = getSharp(valToPx(size.to));
-					const laneHeight = getKeyframeLaneHeight(lane, laneSize.y);
-
-					size.x = fromPos;
-					size.y = laneHeight.y;
-					size.w = getDistance(fromPos, toPos);
-					size.h = laneHeight.h;
-					// get the bounds on a canvas
-					size.bounds = cutBounds({ x: size.x, y: size.y, w: size.w, h: size.h });
-				}
-			});
-
-			areaRect.w = valToPx(areaRect.to, true);
-
-			return toReturn;
-		}
-
-		function drawLanes() {
-			if (!lanes || !lanes.forEach || lanes.length <= 0) {
-				return false;
-			}
-
-			let lanesSizes = getLanesSizes();
-			if (lanesSizes && lanesSizes.sizes) {
-				ctx.save();
-				lanesSizes.sizes.forEach(function lanesSizesIterator(laneSize) {
-
-					if (!laneSize) {
-						return;
-					}
-
-					const selectedColor = laneSize.lane.selectedColor || options.selectedLaneColor;
-					const laneColor = laneSize.lane.color || options.laneColor;
-
-					// Draw lane 
-					if (laneSize.lane.selected && selectedColor) {
-						ctx.fillStyle = selectedColor;
-					} else if (laneSize.index % 2 != 0 && options.useAlternateLaneColor && !laneSize.lane.color) {
-						// Use alternate when lane color not set
-						ctx.fillStyle = options.alternateLaneColor || laneColor;
-					} else {
-						ctx.fillStyle = laneColor;
-					}
-
-					//ctx.fillRect(lanesSizes.areaRect.x, lanesSizes.areaRect.y, lanesSizes.areaRect.w, lanesSizes.areaRect.h);
-					// Note: bounds used instead of the clip while clip is slow!
-					let bounds = laneSize.bounds;
-					if (bounds) {
-						ctx.fillRect(bounds.x, bounds.y, bounds.w, bounds.h);
-						if (laneSize.lane.name) {
-							ctx.fillStyle = options.laneLabelsColor;
-							ctx.fillText(laneSize.lane.name, bounds.x + 10, bounds.y + bounds.h / 2);
-						}
-					}
-
-					if (laneSize.lane.render) {
-						laneSize.lane.render(ctx, laneSize);
-					} else {
-						const keyframeLaneColor = laneSize.lane.keyframesLaneColor || options.keyframesLaneColor;
-
-						let keyframesSize = laneSize.keyframes;
-						if (!keyframesSize || keyframesSize.count <= 1 || !keyframeLaneColor) {
-							return;
-						}
-
-						bounds = keyframesSize.bounds;
-						if (bounds) {
-							ctx.fillStyle = keyframeLaneColor;
-							ctx.fillRect(bounds.x, bounds.y, bounds.w, bounds.h);
-						}
-					}
-				});
-
-				ctx.restore();
-			}
-
-			return true;
-		}
-
-		function cutBounds(rect) {
-			// default bounds: minX, maxX, minY, maxY
-			let minX = 0, maxX = canvas.clientWidth, minY = options.headerHeight || 0, maxY = canvas.clientWidth;
-
-			if (isRectOverlap(rect, { x: minX, y: minY, w: getDistance(minX, maxX), h: getDistance(minY, maxY) })) {
-				let y = Math.max(rect.y, minY);
-				let x = Math.max(rect.x, minX);
-				let offsetW = rect.x - x;
-				let offsetH = rect.y - y;
-				rect.h += offsetH;
-				rect.w += offsetW;
-				rect.x = x;
-				rect.y = y;
-
-				// collision set:
-				if (Math.abs(offsetH) > 0) {
-					rect.overlapY = true;
-				}
-
-				if (Math.abs(offsetW) > 0) {
-					rect.overlapX = true;
-				}
-
-				return rect;// { x: x, y: y, w: w, h: h };
-			}
-			return null;
-		}
-
-		function getLanePosition(laneIndex) {
-			let laneY = options.headerHeight +
-				laneIndex * options.laneHeightPx +
-				laneIndex * options.laneMarginPx;
-			return laneY;
-		}
-
-		function getKeyframeLaneHeight(lane, laneY) {
-			let keyframeLaneHeight = lane.keyframesLaneSizePx || options.keyframesLaneSizePx;
-			if (isNaN(keyframeLaneHeight)) {
-				keyframeLaneHeight = 'auto';
-			}
-
-			if (keyframeLaneHeight == 'auto') {
-				keyframeLaneHeight = Math.floor(options.laneHeightPx * 0.8);
-			}
-
-			if (keyframeLaneHeight > options.laneHeightPx) {
-				keyframeLaneHeight = options.laneHeightPx;
-			}
-
-			const margin = options.laneHeightPx - keyframeLaneHeight;
-			const y = laneY + Math.floor(margin / 2);
-			return { y: y, h: keyframeLaneHeight };
-		}
-
-		function getKeyframePosition(keyframe, laneIndex) {
-			if (!keyframe) {
-				console.log('keyframe should be defined.');
-				return null;
-			}
-
-			let val = keyframe.val;
-			if (isNaN(val)) {
-				return null;
-			}
-
-			// get center of the lane:
-			let laneY = getLanePosition(laneIndex);
-			var y = laneY + options.laneHeightPx / 2 - scrollContainer.scrollTop;
-
-			// keyframe size:
-			let size = options.keyframeSizePx || keyframe.size;
-			if (size == 'auto') {
-				size = options.laneHeightPx / 3;
-			}
-
-			if (size > 0) {
-				if (!isNaN(val)) {
-					let toReturn = { x: Math.floor(valToPx(val)), y: Math.floor(y), size: size, laneY: laneY };
-					return toReturn;
-				}
-			}
-
-			return null;
-		}
-
-		function drawKeyframes() {
-			if (!lanes || !lanes.forEach || lanes.length <= 0) {
-				return false;
-			}
-
-			iterateKeyframes(function seletionIterator(keyframe, keyframeIndex, lane, laneIndex) {
-				var pos = getKeyframePosition(keyframe, laneIndex);
-				if (pos) {
-					if (lane.drawKeyframes !== undefined) {
-						if (!lane.drawKeyframes) {
-							return;
-						}
-					}
-
-					let x = getSharp(pos.x);
-					let y = pos.y;
-					let size = pos.size;
-					let bounds = cutBounds({ x: x - size / 2, y: y - size / 2, w: size, h: size });
-					const customRenderFunction = lane.renderKeyframes || keyframe.render;
-					if (customRenderFunction) {
-						ctx.save();
-						customRenderFunction(ctx, pos, bounds, keyframe, lane);
-						ctx.restore();
-					} else {
-						if (!bounds) {
-							return;
-						}
-
-						ctx.save();
-
-						// Performance FIX: use clip only  when we are in the collision! Clip is slow! 
-						// Other keyframes should be hidden by bounds check.
-						if (bounds && bounds.overlapY) {
-							ctx.beginPath();
-							ctx.rect(0, options.headerHeight || 0, canvas.clientWidth, canvas.clientWidth);
-							ctx.clip();
-						}
-
-						let border = options.keyframeBorderThicknessPx || 0;
-						let shape = keyframe.shape || lane.keyframesShape || options.keyframeShape;
-						let keyframeColor = keyframe.color || options.keyframeColor;
-						if (keyframe.selected) {
-							keyframeColor = keyframe.selectedColor || options.selectedKeyframeColor;
-						}
-
-						if (shape == "rhomb") {
-							ctx.beginPath();
-							ctx.translate(x, y);
-							ctx.rotate(45 * Math.PI / 180);
-							if (border > 0 && options.keyframeBorderColor) {
-								ctx.fillStyle = options.keyframeBorderColor;
-								ctx.rect(-size / 2, -size / 2, size, size);
-								ctx.fill();
-							}
-
-							ctx.fillStyle = keyframeColor;
-							// draw main keyframe data with offset.
-							ctx.translate(border, border);
-							ctx.rect(-size / 2, -size / 2, size - border * 2, size - border * 2);
-							ctx.fill();
-						} else if (shape == "circle") {
-							ctx.beginPath();
-							if (border > 0 && options.keyframeBorderColor) {
-								ctx.fillStyle = options.keyframeBorderColor;
-								ctx.arc(x, y, size, 0, 2 * Math.PI);
-							}
-							ctx.fillStyle = keyframeColor;
-							ctx.arc(x, y, size - border, 0, 2 * Math.PI);
-							ctx.fill();
-						} else if (shape == "rect") {
-							ctx.beginPath();
-							y = y - size / 2;
-							x = x - size / 2;
-							if (border > 0 && options.keyframeBorderColor) {
-								ctx.fillStyle = options.keyframeBorderColor;
-								ctx.rect(x, y, size, size);
-								ctx.fill();
-							}
-
-							ctx.fillStyle = keyframeColor;
-							ctx.rect(x + border, y + border, size - border, size - border);
-							ctx.fill();
-						}
-
-						ctx.restore();
-					}
-				}
-			});
-
-
-		}
-
-		function drawSelection() {
-			if (drag) {
-				return;
-			}
-
-			ctx.save();
-			var thickness = 1;
-			if (selectionRect && selectionRect.enabled) {
-				ctx.setLineDash([4]);
-				ctx.lineWidth = pixelRatio;
-				ctx.strokeStyle = options.selectionColor;
-				ctx.strokeRect(
-					getSharp(selectionRect.x, thickness),
-					getSharp(selectionRect.y, thickness),
-					Math.floor(selectionRect.w),
-					Math.floor(selectionRect.h));
-			}
-			ctx.restore();
-		}
-
-		function drawBackground() {
-			if (options.backgroundColor) {
-				ctx.save();
-				ctx.beginPath();
-				ctx.rect(0, 0, canvas.clientWidth, canvas.clientHeight);
-				ctx.fillStyle = options.backgroundColor;
-				ctx.fill();
-				ctx.restore();
-			} else {
-				// Clear if bg not set.
-				ctx.clearRect(0, 0, canvas.width, canvas.height);
-			}
-		}
-
-		function drawTimeLine() {
-			ctx.save();
-			var thickness = options.timelineThicknessPx;
-			ctx.lineWidth = thickness * pixelRatio;
-			var timeLinePos = getSharp(Math.round(valToPx(timeLine.val)), thickness);
-			ctx.strokeStyle = options.timeIndicatorColor;
-			ctx.fillStyle = ctx.strokeStyle;
-			var y = options.timelineMarginTopPx;
-			ctx.beginPath();
-			drawLine(ctx, timeLinePos, y, timeLinePos, canvas.clientHeight);
-			ctx.stroke();
-
-			if (options.timelineCapWidthPx && options.timelineCapHeightPx) {
-				var rectSize = options.timelineCapWidthPx;
-				var capHeight = options.timelineCapHeightPx;
-				if (options.timelineTriangleCap) {
-					ctx.beginPath();
-					ctx.moveTo(timeLinePos - rectSize / 2, y);
-					ctx.lineTo(timeLinePos + rectSize / 2, y);
-					ctx.lineTo(timeLinePos, capHeight);
-					ctx.closePath();
-					ctx.stroke();
-				}
-				else if (options.timelineRectCap) {
-					ctx.fillRect(timeLinePos - rectSize / 2, y, rectSize, capHeight);
-					ctx.fill();
-				}
-			}
-
-			ctx.restore();
-		}
-
-		function drawHeaderBackground() {
-			if (!isNaN(options.headerHeight) && options.headerHeight > 0) {
-				ctx.save();
-				// draw ticks background
-				ctx.lineWidth = pixelRatio;
-				if (options.headerBackground) {
-					// draw ticks background
-					ctx.lineWidth = pixelRatio;
-					// draw header background
-					ctx.fillStyle = options.headerBackground;
-					ctx.fillRect(0, 0, canvas.clientWidth, options.headerHeight);
-				}
-				else {
-					ctx.clearRect(0, 0, canvas.clientWidth, options.headerHeight);
-				}
-				ctx.restore();
-			}
-		}
-
-		function redraw() {
-			if (window.requestAnimationFrame) {
-				window.requestAnimationFrame(redrawInternal);
-			} else {
-				redrawInternal();
-			}
-		}
-
-		function scrollLeft() {
-			if (scrollContainer.scrollLeft != scrollContainer.scrollWidth) {
-				scrollContainer.scrollLeft = scrollContainer.scrollWidth;
-			}
-		}
-
-		this.scrollLeft = scrollLeft;
-		function redrawInternal() {
-			// Rescale when out of the bounds.
-			if (valToPx(timeLine.val, true) > scrollContainer.scrollWidth) {
-				rescale('play');
-				if (!isPanStarted && (drag && drag.type != 'timeline')) {
-					scrollLeft();
-				}
-			}
-
-			drawBackground();
-			drawLanes();
-			drawHeaderBackground();
-			drawTicks();
-			drawKeyframes();
-			drawSelection();
-			drawTimeLine();
-		}
-
-		function getSharp(pos, thinkess) {
-			if (!thinkess) {
-				thinkess = 1;
-			}
-
-			if (thinkess % 2 == 0) {
-				return pos;
-			}
-
-			return pos + pixelRatio / 2;
-		}
-
-		/**
-		 * Get current time in val.
-		 * @public
-		 */
-		this.getTime = function () {
-			return timeLine.val;
-		}
-
-		function setTimeInternal(val, source) {
-			val = Math.round(val);
-			if (val < 0) {
-				val = 0;
-			}
-
-			if (timeLine.val != val) {
-				timeLine.val = val;
-				emit('timeChanged', { val: val, source: source });
-				return true;
-			}
-
-			return true;
-		}
-
-		this.setTime = function (val) {
-			// Dont allow to change time during drag:
-			if (drag && drag.type == 'timeline') {
-				return false;
-			}
-
-			return setTimeInternal(val, "setTime");
-		};
-
-		this.select = function (value) {
-			performSelection(value);
-			redraw();
-		}
-
-		function getOptions() {
-			return options;
-		}
-
-		function setOptions(options) {
-			options = options || {};
-			// Merge options with the default:
-			for (var key in defaultOptions) {
-				if (Object.prototype.hasOwnProperty.call(defaultOptions, key) && options[key] == undefined) {
-					options[key] = defaultOptions[key];
-				}
-			}
-
-			return options;
-		}
-
-		this.redraw = redraw;
-
-		function controlKeyPressed(e) {
+                        isSelected = !drag.obj.selected
+                    }
+                }
+                // Reverse selected keyframe selection by a click:
+                isChanged |= performSelection(isSelected, drag.obj, 'keyframe', controlKeyPressed(args) || args.shiftKey);
+
+                if (args.shiftKey) {
+                    // change timeline pos:
+                    let convertedVal = mousePosToVal(pos.x, true);
+                    // Set current timeline position if it's not a drag or selection rect small or fast click.
+                    isChanged |= setTimeInternal(convertedVal, 'user');
+                }
+            } else {
+                // deselect keyframes if any:
+                isChanged |= performSelection(false);
+
+                // change timeline pos:
+                let convertedVal = mousePosToVal(pos.x, true);
+                // Set current timeline position if it's not a drag or selection rect small or fast click.
+                isChanged |= setTimeInternal(convertedVal, 'user');
+            }
+
+            return isChanged;
+        }
+
+        function setPanMode(value) {
+            if (isPanMode != value) {
+                isPanMode = value;
+                // Awoid any conflicts with other modes:
+                cleanUpSelection();
+            }
+        }
+
+        this.setPanMode = setPanMode;
+
+        function getSelectedKeyframes() {
+            selectedKeyframes.length = 0;
+            iterateKeyframes(function selectionIterator(keyframe) {
+                if (keyframe && keyframe.selected) {
+                    selectedKeyframes.push(keyframe);
+                }
+            });
+
+            return selectedKeyframes;
+        }
+
+
+        /**
+         * Do the selection.
+         * @param {boolean} isSelected
+         * @param {object} selector can be retangle or keyframe object.
+         * @param {string} mode selector mode. keyframe | rectrangle | all
+         * @param {boolean} ignoreOthers value indicating whether all other object should be reversed.
+         * @return isChanged
+         */
+        function performSelection(isSelected, selector, mode, ignoreOthers) {
+            if (isSelected === undefined) {
+                isSelected = true;
+            }
+
+            let deselectionMode = false;
+            if (!mode) {
+                mode = 'all';
+            }
+
+            if (mode == 'all') {
+                if (!isSelected) {
+                    isSelected = false;
+                }
+
+                deselectionMode = isSelected;
+            }
+
+            selectedKeyframes.length = 0;
+            let isChanged = true;
+
+            iterateKeyframes(function selectionIterator(keyframe, keyframeIndex, lane, laneIndex) {
+                let keyframePos = getKeyframePosition(keyframe, laneIndex);
+                if (keyframePos) {
+                    if ((mode == 'keyframe' && selector == keyframe) ||
+                        (mode == 'rectangle' && selector && isOverlap(keyframePos.x, keyframePos.y, selector))) {
+                        if (keyframe.selected != isSelected) {
+                            keyframe.selected = isSelected;
+                            isChanged = true;
+                        }
+
+                        if (keyframe.selected) {
+                            selectedKeyframes.push(keyframe);
+                        }
+                    } else {
+                        // Deselect all other keyframes.
+                        if (!ignoreOthers && keyframe.selected != deselectionMode) {
+                            keyframe.selected = deselectionMode;
+                            isChanged = deselectionMode;
+                        }
+                    }
+                }
+            });
+
+            if (isChanged) {
+                onKeyframesSelected(selectedKeyframes);
+            }
+
+            return isChanged;
+        }
+
+        function iterateKeyframes(callback) {
+            if (!lanes || !lanes.forEach || lanes.length <= 0) {
+                return false;
+            }
+
+            let nextLane = false;
+            lanes.filter(p => p && !p.hidden).forEach(function lanesIterator(lane, index) {
+                if (!lane || !lane.keyframes || !lane.keyframes.forEach || lane.keyframes.length <= 0) {
+                    return;
+                }
+
+                nextLane = true;
+                lane.keyframes.filter(p => p && !p.hidden).forEach(function keyframesIterator(keyframe, keyframeIndex) {
+                    if (callback && keyframe) {
+                        callback(keyframe, keyframeIndex, lane, index, nextLane);
+                    }
+
+                    nextLane = false;
+                });
+            });
+        }
+
+        function trackMousePos(canvas, mouseArgs) {
+            const pos = getMousePos(canvas, mouseArgs);
+            pos.scrollLeft = scrollContainer.scrollLeft;
+            pos.scrollTop = scrollContainer.scrollTop;
+            pos.val = pxToVal(pos.x + pos.scrollLeft);
+
+            if (startPos) {
+                if (!selectionRect) {
+                    selectionRect = {};
+                }
+
+                // get the pos with the virtualization:
+                let x = Math.floor(startPos.x + (startPos.scrollLeft - pos.scrollLeft));
+                let y = Math.floor(startPos.y + (startPos.scrollTop - pos.scrollTop));
+                selectionRect.x = Math.min(x, pos.x);
+                selectionRect.y = Math.min(y, pos.y);
+                selectionRect.w = Math.max(x, pos.x) - selectionRect.x;
+                selectionRect.h = Math.max(y, pos.y) - selectionRect.y;
+            }
+
+            return pos;
+        }
+
+        function cleanUpSelection() {
+            if (drag && drag.changed) {
+                emit('dragFinished', {
+                    keyframes: drag.selectedItems
+                });
+            }
+
+            startPos = null;
+            drag = null;
+            selectionRect = null;
+            clickDurarion = null;
+            isPanStarted = false;
+            clearMoveInterval();
+        }
+
+        function checkClickDurationOver() {
+            // Duration before the selection can be tracked.
+            if ((clickDurarion && new Date() - clickDurarion > clickDetectionMs)) {
+                return true;
+            }
+
+            return false;
+        }
+
+        //stepsCanFit
+        rescale();
+
+        /**
+         * Automatically move canvas when selection and mouse over the bounds.
+         */
+        function startAutoScrollInterval() {
+            if (!intervalReference) {
+                // Repeat move calls to
+                intervalReference = setInterval(function () {
+                    onMouseMove();
+                }, 50);
+            }
+        }
+
+        function clearMoveInterval() {
+            if (intervalReference) {
+                clearInterval(intervalReference);
+                intervalReference = null;
+            }
+
+            lastCallDate = null;
+        }
+
+        function checkUpdateSpeedIsFast() {
+            // Dont update too often.
+            if (lastCallDate && new Date() - lastCallDate <= 10) {
+                return true;
+            }
+
+            lastCallDate = new Date();
+            return false;
+        }
+
+
+        function scrollByPan(start, pos) {
+            if (!start || !pos) {
+                return;
+            }
+
+            let newTop = Math.round(start.y - pos.y);
+            let offsetX = Math.round(start.x - pos.x);
+            let newLeft = start.scrollLeft + offsetX;
+
+            if (offsetX > 0) {
+                rescale(newLeft + canvas.clientWidth);
+            }
+
+            if (offsetX > 0 && newLeft + canvas.clientWidth >= scrollContainer.scrollWidth - 5) {
+                scrollContainer.scrollLeft = scrollContainer.scrollWidth;
+            } else {
+                scrollContainer.scrollLeft = newLeft;
+            }
+            scrollContainer.scrollTop = newTop;
+
+        }
+
+        function scrollBySelectionOutOfBounds(pos) {
+            let x = pos.x;
+            let y = pos.y;
+            let isChanged = false;
+            let speedX = 0;
+            let speedY = 0;
+            let isLeft = x <= 0;
+            let isRight = x >= canvas.clientWidth;
+            let isTop = y <= 0;
+            let isBottom = y >= canvas.clientHeight;
+            let newWidth = null;
+            let newHeight = null;
+            if (isLeft || isRight || isTop || isBottom) {
+                // Auto move init
+                startAutoScrollInterval();
+
+                if (checkUpdateSpeedIsFast()) {
+                    return;
+                }
+
+                let scrollSpeedMultiplier = (isNaN(options.scrollByDragSpeed) ? 1 : options.scrollByDragSpeed);
+                if (isLeft) {
+                    // Get normilized speed.
+                    speedX = -getDistance(x, 0) * scrollSpeedMultiplier
+                } else if (isRight) {
+                    // Get normalized speed:
+                    speedX = getDistance(x, canvas.clientWidth) * scrollSpeedMultiplier;
+                    newWidth = scrollContainer.scrollLeft + canvas.clientWidth + speedX;
+                }
+
+                if (isTop) {
+                    // Get normilized speed.
+                    speedY = -getDistance(x, 0) * scrollSpeedMultiplier / 4;
+                } else if (isBottom) {
+                    // Get normalized speed:
+                    speedY = getDistance(x, canvas.clientHeight) * scrollSpeedMultiplier / 4;
+                    newHeight = scrollContainer.scrollTop + canvas.clientHeight;
+                }
+            } else {
+                clearMoveInterval();
+            }
+
+            if (newWidth || newHeight) {
+                rescale('scrollBySelection', newWidth, newHeight);
+            }
+
+            if (Math.abs(speedX) > 0) {
+                scrollContainer.scrollLeft += speedX;
+                isChanged = true;
+            }
+
+            if (Math.abs(speedY) > 0) {
+                scrollContainer.scrollTop += speedY;
+                isChanged = true;
+            }
+
+            return isChanged;
+        }
+
+        // Find ms from the the px coordinates
+        function pxToVal(coords, globalCoords) {
+            if (!globalCoords) {
+                coords -= options.leftMarginPx;
+            }
+            var ms = coords / options.stepPx * options.zoom;
+            return ms;
+        }
+
+        // convert
+        function valToPx(ms, globalCoords) {
+            // Respect current scroll container offset. (virtualization)
+            if (!globalCoords) {
+                var x = scrollContainer.scrollLeft;
+                ms -= pxToVal(x);
+            }
+
+            return (ms * options.stepPx / options.zoom);
+        }
+
+        function snapVal(ms) {
+            // Apply snap to steps if enabled.
+            if (options.snapsPerSeconds && options.snapEnabled) {
+                var stopsPerPixel = (1000 / options.snapsPerSeconds);
+                let step = ms / stopsPerPixel;
+                var stepsFit = Math.round(step);
+                ms = Math.round(stepsFit * stopsPerPixel);
+            }
+
+            if (ms < 0) {
+                ms = 0;
+            }
+
+            return ms;
+        }
+
+        function mousePosToVal(x, snapEnabled) {
+            let convertedVal = pxToVal(scrollContainer.scrollLeft + Math.min(x, canvas.clientWidth));
+            convertedVal = Math.round(convertedVal);
+            if (snapEnabled) {
+                convertedVal = snapVal(convertedVal);
+            }
+
+            return convertedVal;
+        }
+
+        function findGoodStep(originaStep, divisionCheck) {
+            var step = originaStep;
+            var lastDistance = null;
+            var pow = getPowArgument(originaStep);
+            for (var i = 0; i < denominators.length; i++) {
+                var denominator = denominators[i];
+                var calculatedStep = denominator * Math.pow(10, pow);
+                if (divisionCheck && (divisionCheck % calculatedStep) != 0) {
+                    continue;
+                }
+                var distance = getDistance(originaStep, calculatedStep);
+
+                if (distance == 0 || (distance <= 0.1 && pow > 0)) {
+                    lastDistance = distance;
+                    step = calculatedStep;
+                    break;
+                } else if (!lastDistance || lastDistance > distance) {
+                    lastDistance = distance;
+                    step = calculatedStep;
+                }
+            }
+
+            return step;
+        }
+
+        function drawTicks() {
+            ctx.save();
+
+            var areaWidth = scrollContainer.scrollWidth - options.leftMarginPx;
+            var from = pxToVal(0);
+            var to = pxToVal(areaWidth);
+            var dist = getDistance(from, to);
+            // normalize step.
+            var stepsCanFit = areaWidth / options.stepPx;
+            let realStep = dist / stepsCanFit;
+            // Find the nearest 'beautiful' step for a gauge. This step should be devided by 1/2/5!
+            //let step = realStep;
+            let step = findGoodStep(realStep);
+            var goodStepDistancePx = areaWidth / (dist / step);
+            var smallStepsCanFit = goodStepDistancePx / options.stepSmallPx;
+            var realSmallStep = step / smallStepsCanFit;
+            var smallStep = findGoodStep(realSmallStep, step);
+            if (step % smallStep != 0) {
+                smallStep = realSmallStep;
+            }
+            // filter to draw only visible
+            var visibleFrom = pxToVal(scrollContainer.scrollLeft + options.leftMarginPx);
+            var visibleTo = pxToVal(scrollContainer.scrollLeft + scrollContainer.clientWidth);
+            // Find beautiful start point:
+            from = Math.floor(visibleFrom / step) * step;
+
+            // Find a beautiful end point:
+            to = Math.ceil(visibleTo / step) * step + step;
+
+            let lastTextX = null;
+            for (var i = from; i <= to; i += step) {
+                var pos = valToPx(i);
+                var sharpPos = getSharp(Math.round(pos));
+                ctx.save();
+                ctx.beginPath();
+                ctx.setLineDash([4]);
+                ctx.lineWidth = pixelRatio;
+                ctx.strokeStyle = options.tickColor;
+                drawLine(ctx, sharpPos, (options.headerHeight || 0) / 2, sharpPos, canvas.clientHeight);
+                ctx.stroke();
+
+                ctx.fillStyle = options.labelsColor;
+                if (options.ticksFont) {
+                    ctx.font = options.ticksFont;
+                }
+
+                var text = msToHMS(i)
+                var textSize = ctx.measureText(text);
+
+                let textX = sharpPos - textSize.width / 2;
+                // skip text render if there is no space for it.
+                if (isNaN(lastTextX) || lastTextX <= textX) {
+
+                    lastTextX = textX + textSize.width;
+                    ctx.fillText(text, textX, 10);
+                }
+
+                ctx.restore();
+                // Draw small steps
+                for (let x = i + smallStep; x < i + step; x += smallStep) {
+                    var nextPos = valToPx(x);
+                    var nextSharpPos = getSharp(Math.floor(nextPos));
+                    ctx.beginPath();
+                    ctx.lineWidth = pixelRatio;
+                    ctx.strokeStyle = options.tickColor;
+                    drawLine(ctx, nextSharpPos, (options.headerHeight || 0) / 1.3, nextSharpPos, options.headerHeight);
+                    ctx.stroke();
+                }
+            }
+
+            ctx.restore();
+        }
+
+        function getLanesSizes() {
+            let toReturn = {
+                sizes: [],
+                areaRect: {
+                    x: 0,
+                    y: 0,
+                    w: 0,
+                    h: 0,
+                    from: null,
+                    to: null
+                }
+            }
+
+            if (!options.laneHeightPx) {
+                console.log('laneHeightPx should be set.');
+                return toReturn;
+            }
+
+            if (!lanes || !lanes.forEach || lanes.length <= 0) {
+                return toReturn;
+            }
+
+            const areaRect = toReturn.areaRect;
+
+            lanes.filter(p => p && !p.hidden).forEach(function lanesIterator(lane, index) {
+                if (!lane) {
+                    return;
+                }
+
+                // draw with scroll virtualization:
+                var globalLaneY = getLanePosition(index);
+                var laneY = globalLaneY - scrollContainer.scrollTop;
+                if (index == 0) {
+                    areaRect.y = laneY;
+                }
+
+                areaRect.h = Math.max(globalLaneY + options.laneHeightPx, areaRect.h);
+
+                var laneSize = {
+                    x: 0,
+                    y: laneY,
+                    w: canvas.clientWidth,
+                    h: options.laneHeightPx,
+                    clientWidth: canvas.clientWidth,
+                    clientHeight: canvas.clientHeight,
+                    lane: lane,
+                    index: index,
+                    keyframes: {
+                        from: null,
+                        to: null,
+                        count: lane.keyframes ? lane.keyframes.length : 0,
+                    }
+                };
+
+                // get the bounds on a canvas. used instead of the clip (clip is slow)
+                laneSize.bounds = cutBounds({
+                    x: laneSize.x,
+                    y: laneSize.y,
+                    w: laneSize.w,
+                    h: laneSize.h
+                });
+
+                toReturn.sizes.push(laneSize);
+                let size = laneSize.keyframes;
+
+                if (!lane.keyframes || !lane.keyframes.forEach || lane.keyframes.length <= 0) {
+                    return;
+                }
+
+                // Get min and max ms to draw keyframe lane:
+                lane.keyframes.forEach(function keyframesIterator(keyframe) {
+                    let val = keyframe.val;
+
+                    if (size && keyframe && !isNaN(val)) {
+                        size.from = size.from == null ? val : Math.min(val, size.from);
+                        size.to = size.to == null ? val : Math.max(val, size.to);
+                    }
+                });
+
+                // get absolute min and max:
+                areaRect.from = areaRect.from == null ? size.from : Math.min(size.from, areaRect.from);
+                areaRect.to = areaRect.to == null ? size.to : Math.max(size.to, areaRect.to);
+
+                // get keyframes lane size
+                if (laneSize && !isNaN(size.from) && !isNaN(size.to)) {
+                    // draw keyframes lane.
+                    var fromPos = getSharp(valToPx(size.from))
+                    var toPos = getSharp(valToPx(size.to));
+                    const laneHeight = getKeyframeLaneHeight(lane, laneSize.y);
+
+                    size.x = fromPos;
+                    size.y = laneHeight.y;
+                    size.w = getDistance(fromPos, toPos);
+                    size.h = laneHeight.h;
+                    // get the bounds on a canvas
+                    size.bounds = cutBounds({
+                        x: size.x,
+                        y: size.y,
+                        w: size.w,
+                        h: size.h
+                    });
+                }
+            });
+
+            areaRect.w = valToPx(areaRect.to, true);
+
+            return toReturn;
+        }
+
+        function drawLanes() {
+            if (!lanes || !lanes.forEach || lanes.length <= 0) {
+                return false;
+            }
+
+            let lanesSizes = getLanesSizes();
+            if (lanesSizes && lanesSizes.sizes) {
+                ctx.save();
+                lanesSizes.sizes.forEach(function lanesSizesIterator(laneSize) {
+
+                    if (!laneSize) {
+                        return;
+                    }
+
+                    const selectedColor = laneSize.lane.selectedColor || options.selectedLaneColor;
+                    const laneColor = laneSize.lane.color || options.laneColor;
+
+                    // Draw lane
+                    if (laneSize.lane.selected && selectedColor) {
+                        ctx.fillStyle = selectedColor;
+                    } else if (laneSize.index % 2 != 0 && options.useAlternateLaneColor && !laneSize.lane.color) {
+                        // Use alternate when lane color not set
+                        ctx.fillStyle = options.alternateLaneColor || laneColor;
+                    } else {
+                        ctx.fillStyle = laneColor;
+                    }
+
+                    //ctx.fillRect(lanesSizes.areaRect.x, lanesSizes.areaRect.y, lanesSizes.areaRect.w, lanesSizes.areaRect.h);
+                    // Note: bounds used instead of the clip while clip is slow!
+                    let bounds = laneSize.bounds;
+                    if (bounds) {
+                        ctx.fillRect(bounds.x, bounds.y, bounds.w, bounds.h);
+                        if (laneSize.lane.name) {
+                            ctx.fillStyle = options.laneLabelsColor;
+                            ctx.fillText(laneSize.lane.name, bounds.x + 10, bounds.y + bounds.h / 2);
+                        }
+                    }
+
+                    if (laneSize.lane.render) {
+                        laneSize.lane.render(ctx, laneSize);
+                    } else {
+                        const keyframeLaneColor = laneSize.lane.keyframesLaneColor || options.keyframesLaneColor;
+
+                        let keyframesSize = laneSize.keyframes;
+                        if (!keyframesSize || keyframesSize.count <= 1 || !keyframeLaneColor) {
+                            return;
+                        }
+
+                        bounds = keyframesSize.bounds;
+                        if (bounds) {
+                            ctx.fillStyle = keyframeLaneColor;
+                            ctx.fillRect(bounds.x, bounds.y, bounds.w, bounds.h);
+                        }
+                    }
+                });
+
+                ctx.restore();
+            }
+
+            return true;
+        }
+
+        function cutBounds(rect) {
+            // default bounds: minX, maxX, minY, maxY
+            let minX = 0,
+                maxX = canvas.clientWidth,
+                minY = options.headerHeight || 0,
+                maxY = canvas.clientWidth;
+
+            if (isRectOverlap(rect, {
+                    x: minX,
+                    y: minY,
+                    w: getDistance(minX, maxX),
+                    h: getDistance(minY, maxY)
+                })) {
+                let y = Math.max(rect.y, minY);
+                let x = Math.max(rect.x, minX);
+                let offsetW = rect.x - x;
+                let offsetH = rect.y - y;
+                rect.h += offsetH;
+                rect.w += offsetW;
+                rect.x = x;
+                rect.y = y;
+
+                // collision set:
+                if (Math.abs(offsetH) > 0) {
+                    rect.overlapY = true;
+                }
+
+                if (Math.abs(offsetW) > 0) {
+                    rect.overlapX = true;
+                }
+
+                return rect; // { x: x, y: y, w: w, h: h };
+            }
+            return null;
+        }
+
+        function getLanePosition(laneIndex) {
+            let laneY = options.headerHeight +
+                laneIndex * options.laneHeightPx +
+                laneIndex * options.laneMarginPx;
+            return laneY;
+        }
+
+        function getKeyframeLaneHeight(lane, laneY) {
+            let keyframeLaneHeight = lane.keyframesLaneSizePx || options.keyframesLaneSizePx;
+            if (isNaN(keyframeLaneHeight)) {
+                keyframeLaneHeight = 'auto';
+            }
+
+            if (keyframeLaneHeight == 'auto') {
+                keyframeLaneHeight = Math.floor(options.laneHeightPx * 0.8);
+            }
+
+            if (keyframeLaneHeight > options.laneHeightPx) {
+                keyframeLaneHeight = options.laneHeightPx;
+            }
+
+            const margin = options.laneHeightPx - keyframeLaneHeight;
+            const y = laneY + Math.floor(margin / 2);
+            return {
+                y: y,
+                h: keyframeLaneHeight
+            };
+        }
+
+        function getKeyframePosition(keyframe, laneIndex) {
+            if (!keyframe) {
+                console.log('keyframe should be defined.');
+                return null;
+            }
+
+            let val = keyframe.val;
+            if (isNaN(val)) {
+                return null;
+            }
+
+            // get center of the lane:
+            let laneY = getLanePosition(laneIndex);
+            var y = laneY + options.laneHeightPx / 2 - scrollContainer.scrollTop;
+
+            // keyframe size:
+            let size = options.keyframeSizePx || keyframe.size;
+            if (size == 'auto') {
+                size = options.laneHeightPx / 3;
+            }
+
+            if (size > 0) {
+                if (!isNaN(val)) {
+                    let toReturn = {
+                        x: Math.floor(valToPx(val)),
+                        y: Math.floor(y),
+                        size: size,
+                        laneY: laneY
+                    };
+                    return toReturn;
+                }
+            }
+
+            return null;
+        }
+
+        function drawKeyframes() {
+            if (!lanes || !lanes.forEach || lanes.length <= 0) {
+                return false;
+            }
+
+            iterateKeyframes(function seletionIterator(keyframe, keyframeIndex, lane, laneIndex) {
+                var pos = getKeyframePosition(keyframe, laneIndex);
+                if (pos) {
+                    if (lane.drawKeyframes !== undefined) {
+                        if (!lane.drawKeyframes) {
+                            return;
+                        }
+                    }
+
+                    let x = getSharp(pos.x);
+                    let y = pos.y;
+                    let size = pos.size;
+                    let bounds = cutBounds({
+                        x: x - size / 2,
+                        y: y - size / 2,
+                        w: size,
+                        h: size
+                    });
+                    const customRenderFunction = lane.renderKeyframes || keyframe.render;
+                    if (customRenderFunction) {
+                        ctx.save();
+                        customRenderFunction(ctx, pos, bounds, keyframe, lane);
+                        ctx.restore();
+                    } else {
+                        if (!bounds) {
+                            return;
+                        }
+
+                        ctx.save();
+
+                        // Performance FIX: use clip only  when we are in the collision! Clip is slow!
+                        // Other keyframes should be hidden by bounds check.
+                        if (bounds && bounds.overlapY) {
+                            ctx.beginPath();
+                            ctx.rect(0, options.headerHeight || 0, canvas.clientWidth, canvas.clientWidth);
+                            ctx.clip();
+                        }
+
+                        let border = options.keyframeBorderThicknessPx || 0;
+                        let shape = keyframe.shape || lane.keyframesShape || options.keyframeShape;
+                        let keyframeColor = keyframe.color || options.keyframeColor;
+                        if (keyframe.selected) {
+                            keyframeColor = keyframe.selectedColor || options.selectedKeyframeColor;
+                        }
+
+                        if (shape == "rhomb") {
+                            ctx.beginPath();
+                            ctx.translate(x, y);
+                            ctx.rotate(45 * Math.PI / 180);
+                            if (border > 0 && options.keyframeBorderColor) {
+                                ctx.fillStyle = options.keyframeBorderColor;
+                                ctx.rect(-size / 2, -size / 2, size, size);
+                                ctx.fill();
+                            }
+
+                            ctx.fillStyle = keyframeColor;
+                            // draw main keyframe data with offset.
+                            ctx.translate(border, border);
+                            ctx.rect(-size / 2, -size / 2, size - border * 2, size - border * 2);
+                            ctx.fill();
+                        } else if (shape == "circle") {
+                            ctx.beginPath();
+                            if (border > 0 && options.keyframeBorderColor) {
+                                ctx.fillStyle = options.keyframeBorderColor;
+                                ctx.arc(x, y, size, 0, 2 * Math.PI);
+                            }
+                            ctx.fillStyle = keyframeColor;
+                            ctx.arc(x, y, size - border, 0, 2 * Math.PI);
+                            ctx.fill();
+                        } else if (shape == "rect") {
+                            ctx.beginPath();
+                            y = y - size / 2;
+                            x = x - size / 2;
+                            if (border > 0 && options.keyframeBorderColor) {
+                                ctx.fillStyle = options.keyframeBorderColor;
+                                ctx.rect(x, y, size, size);
+                                ctx.fill();
+                            }
+
+                            ctx.fillStyle = keyframeColor;
+                            ctx.rect(x + border, y + border, size - border, size - border);
+                            ctx.fill();
+                        }
+
+                        ctx.restore();
+                    }
+                }
+            });
+
+
+        }
+
+        function drawSelection() {
+            if (drag) {
+                return;
+            }
+
+            ctx.save();
+            var thickness = 1;
+            if (selectionRect && selectionRect.enabled) {
+                ctx.setLineDash([4]);
+                ctx.lineWidth = pixelRatio;
+                ctx.strokeStyle = options.selectionColor;
+                ctx.strokeRect(
+                    getSharp(selectionRect.x, thickness),
+                    getSharp(selectionRect.y, thickness),
+                    Math.floor(selectionRect.w),
+                    Math.floor(selectionRect.h));
+            }
+            ctx.restore();
+        }
+
+        function drawBackground() {
+            if (options.backgroundColor) {
+                ctx.save();
+                ctx.beginPath();
+                ctx.rect(0, 0, canvas.clientWidth, canvas.clientHeight);
+                ctx.fillStyle = options.backgroundColor;
+                ctx.fill();
+                ctx.restore();
+            } else {
+                // Clear if bg not set.
+                ctx.clearRect(0, 0, canvas.width, canvas.height);
+            }
+        }
+
+        function drawTimeLine() {
+            ctx.save();
+            var thickness = options.timelineThicknessPx;
+            ctx.lineWidth = thickness * pixelRatio;
+            var timeLinePos = getSharp(Math.round(valToPx(timeLine.val)), thickness);
+            ctx.strokeStyle = options.timeIndicatorColor;
+            ctx.fillStyle = ctx.strokeStyle;
+            var y = options.timelineMarginTopPx;
+            ctx.beginPath();
+            drawLine(ctx, timeLinePos, y, timeLinePos, canvas.clientHeight);
+            ctx.stroke();
+
+            if (options.timelineCapWidthPx && options.timelineCapHeightPx) {
+                var rectSize = options.timelineCapWidthPx;
+                var capHeight = options.timelineCapHeightPx;
+                if (options.timelineTriangleCap) {
+                    ctx.beginPath();
+                    ctx.moveTo(timeLinePos - rectSize / 2, y);
+                    ctx.lineTo(timeLinePos + rectSize / 2, y);
+                    ctx.lineTo(timeLinePos, capHeight);
+                    ctx.closePath();
+                    ctx.stroke();
+                } else if (options.timelineRectCap) {
+                    ctx.fillRect(timeLinePos - rectSize / 2, y, rectSize, capHeight);
+                    ctx.fill();
+                }
+            }
+
+            ctx.restore();
+        }
+
+        function drawHeaderBackground() {
+            if (!isNaN(options.headerHeight) && options.headerHeight > 0) {
+                ctx.save();
+                // draw ticks background
+                ctx.lineWidth = pixelRatio;
+                if (options.headerBackground) {
+                    // draw ticks background
+                    ctx.lineWidth = pixelRatio;
+                    // draw header background
+                    ctx.fillStyle = options.headerBackground;
+                    ctx.fillRect(0, 0, canvas.clientWidth, options.headerHeight);
+                } else {
+                    ctx.clearRect(0, 0, canvas.clientWidth, options.headerHeight);
+                }
+                ctx.restore();
+            }
+        }
+
+        function redraw() {
+            if (window.requestAnimationFrame) {
+                //window.requestAnimationFrame.call(this, redrawInternal);
+                window.requestAnimationFrame(redrawInternal);
+            } else {
+                redrawInternal();
+            }
+        }
+
+        function scrollLeft() {
+            if (scrollContainer.scrollLeft != scrollContainer.scrollWidth) {
+                scrollContainer.scrollLeft = scrollContainer.scrollWidth;
+            }
+        }
+
+        this.scrollLeft = scrollLeft;
+
+        function redrawInternal() {
+            // Rescale when out of the bounds.
+            if (valToPx(timeLine.val, true) > scrollContainer.scrollWidth) {
+                rescale('play');
+                if (!isPanStarted && (drag && drag.type != 'timeline')) {
+                    scrollLeft();
+                }
+            }
+
+            drawBackground();
+            drawLanes();
+            drawHeaderBackground();
+            drawTicks();
+            drawKeyframes();
+            drawSelection();
+            drawTimeLine();
+        }
+
+        function getSharp(pos, thinkess) {
+            if (!thinkess) {
+                thinkess = 1;
+            }
+
+            if (thinkess % 2 == 0) {
+                return pos;
+            }
+
+            return pos + pixelRatio / 2;
+        }
+
+        /**
+         * Get current time in val.
+         * @public
+         */
+        this.getTime = function () {
+            return timeLine.val;
+        }
+
+        function setTimeInternal(val, source) {
+            val = Math.round(val);
+            if (val < 0) {
+                val = 0;
+            }
+
+            if (timeLine.val != val) {
+                timeLine.val = val;
+                emit('timeChanged', {
+                    val: val,
+                    source: source
+                });
+                return true;
+            }
+
+            return true;
+        }
+
+        this.setTime = function (val) {
+            // Dont allow to change time during drag:
+            if (drag && drag.type == 'timeline') {
+                return false;
+            }
+
+            return setTimeInternal(val, "setTime");
+        };
+
+        this.select = function (value) {
+            performSelection(value);
+            redraw();
+        }
+
+        function getOptions() {
+            return options;
+        }
+
+        function setOptions(options) {
+            options = options || {};
+            // Merge options with the default:
+            for (var key in defaultOptions) {
+                if (Object.prototype.hasOwnProperty.call(defaultOptions, key) && options[key] == undefined) {
+                    options[key] = defaultOptions[key];
+                }
+            }
+
+            return options;
+        }
+
+        this.redraw = redraw;
+
+        function controlKeyPressed(e) {
             return (options.controlKeyIsMetaKey || defaultOptions.controlKeyIsMetaKey) ? e.metaKey : e.ctrlKey;
         }
 
-		function onKeyframesSelected(keyframe) {
-			emit('selected', keyframe);
-		}
+        function onKeyframesSelected(keyframe) {
+            emit('selected', keyframe);
+        }
 
-		let subscriptions = [];
+        let subscriptions = [];
 
-		this.onScroll = function (callback) {
-			this.on('scroll', callback);
-		}
+        this.onScroll = function (callback) {
+            this.on('scroll', callback);
+        }
 
-		// on event.
-		this.on = function (topic, callback) {
-			if (!callback) {
-				return;
-			}
+        // on event.
+        this.on = function (topic, callback) {
+            if (!callback) {
+                return;
+            }
 
-			subscriptions.push({ topic: topic, callback: callback });
-		}
+            subscriptions.push({
+                topic: topic,
+                callback: callback
+            });
+        }
 
-		// emit event.
-		function emit(topic, args) {
-			for (var i = subscriptions.length - 1; i >= 0; i--) {
-				var sub = subscriptions[i];
-				if (sub.topic == topic && sub.callback) {
-					sub.callback(args);
-				}
-			}
-		}
+        // emit event.
+        function emit(topic, args) {
+            for (var i = subscriptions.length - 1; i >= 0; i--) {
+                var sub = subscriptions[i];
+                if (sub.topic == topic && sub.callback) {
+                    sub.callback(args);
+                }
+            }
+        }
 
-		this.getOptions = getOptions;
-		this.setOptions = function (options) {
-			setOptions(options);
-			rescale();
-			redraw();
-		}
+        this.getOptions = getOptions;
+        this.setOptions = function (options) {
+            setOptions(options);
+            rescale();
+            redraw();
+        }
 
-		function getLanes() {
-			return lanes;
-		}
+        function getLanes() {
+            return lanes;
+        }
 
-		function setLanes(data) {
-			lanes = data;
-		}
+        function setLanes(data) {
+            lanes = data;
+        }
 
-		this.setLanes = setLanes;
-		this.getLanes = getLanes;
-		this.rescale = rescale;
-		this.redraw = redraw;
-		this.emit = emit;
+        this.setLanes = setLanes;
+        this.getLanes = getLanes;
+        this.rescale = rescale;
+        this.redraw = redraw;
+        this.emit = emit;
 
-		// expose private methods:
-		this.__cutBounds = cutBounds;
+        // expose private methods:
+        this.__cutBounds = cutBounds;
 
-		/**
-		 * Remove the event from the subscriptions list.
-		 * @param {string} topic 
-		 * @param {Function} callback 
-		 */
-		this.off = function (topic, callback) {
-			for (var i = subscriptions.length - 1; i >= 0; i--) {
-				var sub = subscriptions[i];
-				if (sub.topic == topic && sub.callback == callback) {
-					subscriptions = subscriptions.filter(function (ele) {
-						return ele != callback;
-					});
-				}
-			}
-		}
+        /**
+         * Remove the event from the subscriptions list.
+         * @param {string} topic
+         * @param {Function} callback
+         */
+        this.off = function (topic, callback) {
+            for (var i = subscriptions.length - 1; i >= 0; i--) {
+                var sub = subscriptions[i];
+                if (sub.topic == topic && sub.callback == callback) {
+                    subscriptions = subscriptions.filter(function (ele) {
+                        return ele != callback;
+                    });
+                }
+            }
+        }
 
-		rescale();
-		redraw();
+        rescale();
+        redraw();
 
-		return this;
-	}
-
-	return instance;
-}));
+        return this;
+    }
+}

--- a/index.js
+++ b/index.js
@@ -1638,7 +1638,7 @@
 
 		function redraw() {
 			if (window.requestAnimationFrame) {
-				window.requestAnimationFrame.call(this, redrawInternal);
+				window.requestAnimationFrame(redrawInternal);
 			} else {
 				redrawInternal();
 			}

--- a/index.js
+++ b/index.js
@@ -282,13 +282,8 @@
 		if (!options.stepPx) {
 			options.stepPx = defaultOptions.stepPx;
 		}
-		if (!options.snapsPerSeconds) {
-			if (options.snapsPerSeconds < 0) {
-				options.snapsPerSeconds = 0;
-			} else if (options.snapsPerSeconds > 60) {
-				options.snapsPerSeconds = 60;
-			}
-		}
+
+		options.snapsPerSeconds = Math.max(0, Math.min(60, options.snapsPerSeconds));
 
 		let timeLine = {
 			val: 0,

--- a/index.js
+++ b/index.js
@@ -464,7 +464,7 @@ export default class AnimationTimeline {
             // Check whether we can drag timeline.
             var timeLinePos = valToPx(timeLine.val);
             let width = Math.max(((options.timelineThicknessPx || 1) * pixelRatio), options.timelineCapWidthPx * pixelRatio || 1) + helperSelector;
-            if (pos.x >= timeLinePos - width / 2 && pos.x <= timeLinePos + width / 2) {
+            if (pos.y <= options.headerHeight || (pos.x >= timeLinePos - width / 2 && pos.x <= timeLinePos + width / 2)) {
                 return {
                     obj: timeLine,
                     type: "timeline"


### PR DESCRIPTION
#### Fixes:
- option _snapsPerSeconds_ was not evaluated properly
- Fix for Issue #4 
- Added declaration for _val_ to make the linter happy
- Taking scroll position into account to get the correct time when the timeline is scrolled. I ran into this when trying to create keyframes on doubleclick. When the timeline was scrolled, the time in the given object was not correct.

#### Enhancements:
- Added option to use Meta key instead of Ctrl key when running on macOS (might be detected automatically as a further improvement)
- Added _doubleclick_ event
- Emitting _mousedown_ event

The last commit is a breaking one (398001c), you may ignore this. I could not avoid reformatting the source. This is the way I use the component at the moment: Basically I just changed AnimationTimeline into a class and got rid of the preamble since the transpiler will do this. After refactoring to .ts this should become obsolete.