### PR TITLE
Allow scrubbing even if the playhead is not selected when mouse is in the header area. This makes it easier to scrub since the user does not have to aim the thin line.

### DIFF
--- a/index.js
+++ b/index.js
@@ -475,7 +475,7 @@
 			// Check whether we can drag timeline.
 			var timeLinePos = valToPx(timeLine.val);
 			let width = Math.max(((options.timelineThicknessPx || 1) * pixelRatio), options.timelineCapWidthPx * pixelRatio || 1) + helperSelector;
-			if (pos.x >= timeLinePos - width / 2 && pos.x <= timeLinePos + width / 2) {
+			if (pos.y <= options.headerHeight || (pos.x >= timeLinePos - width / 2 && pos.x <= timeLinePos + width / 2)) {
 				return { obj: timeLine, type: "timeline" };
 			}
 		}


### PR DESCRIPTION
Sorry for the noisy diff, I don't know where these whitespace diffs come from, didn't reformat this time. I am using vscode.

Essentially it is just line 479: 
`if (pos.y <= options.headerHeight || (pos.x >= timeLinePos - width / 2 && pos.x <= timeLinePos + width / 2)) {`